### PR TITLE
Fix for #97 Changes to make hprof dump compatible to python3 while maintaining compatibility with python 2*

### DIFF
--- a/tools/hprof/dump_classes_from_hprof.py
+++ b/tools/hprof/dump_classes_from_hprof.py
@@ -68,7 +68,7 @@ class HprofTag(enum.Enum):
     HEAP_DUMP_END = 0x2C
     CPU_SAMPLES = 0x0D
     CONTROL_SETTINGS = 0x0E
-    
+
 class HeapTag(enum.Enum):
     # standard
     ROOT_UNKNOWN = 0xFF

--- a/tools/hprof/dump_classes_from_hprof.py
+++ b/tools/hprof/dump_classes_from_hprof.py
@@ -150,11 +150,13 @@ class HprofBasic(enum.Enum):
             return byte_stream.next_eight_bytes()
         else:
             raise Exception('Invalid HprofBasic type: %s' % self)
+
 def getArray(value):
     try:
         return array(value)
     except TypeError:
-        return array(str(value)[0]) 
+        return array(str(value)[0])
+        
 class Record(object):
     record_struct_format = b'>BII'
     record_struct = struct.Struct(record_struct_format)

--- a/tools/hprof/dump_classes_from_hprof.py
+++ b/tools/hprof/dump_classes_from_hprof.py
@@ -165,8 +165,6 @@ class Record(object):
 
     @staticmethod
     def read_from_stream(hprof_data, instream):
-        print(struct.calcsize(Record.record_struct_format))
-        print(instream.read(struct.calcsize(Record.record_struct_format)))
         (tag, time_offset_us, length) = Record.record_struct.unpack(instream.read(struct.calcsize(Record.record_struct_format)))
         data = getArray(b'B')
         data.fromstring(instream.read(length))

--- a/tools/hprof/dump_classes_from_hprof.py
+++ b/tools/hprof/dump_classes_from_hprof.py
@@ -23,11 +23,12 @@ import struct
 import subprocess
 import sys
 import tempfile
+from functools import reduce
 
 def parse_hprof_dump(instream):
     # Read the tag - a null-terminated string
     iter_until_null = iter(lambda: instream.read(1), '\x00')
-    tag = reduce(operator.concat, iter_until_null, '')
+    tag = reduce(operator.concat, iter_until_null, b'')
 
     big_endian_unsigned_4byte_integer = struct.Struct(b'>I')
     sizeof_id = big_endian_unsigned_4byte_integer.unpack(instream.read(4))[0]


### PR DESCRIPTION
Few fixes:
1-import functools to support reduce
2. read returns bytes instead of string in python3.Made reduce work with bytes
3. replaced deprecated iter\* with the recommended replacements
4. workaround to generate array in a compatible way in python2 and python3. 
