### PR TITLE
Patch 1

### DIFF
--- a/include/Match.h
+++ b/include/Match.h
@@ -584,4 +584,14 @@ match_t<T, std::tuple<> > can_delete() {
   };
 }
 
+/** Match which checks is_seed helper for DexMembers */
+template<typename T>
+match_t<T, std::tuple<> > is_seed() {
+  return {
+    [](const T* t) {
+      return is_seed(t);
+    }
+  };
+}
+
 } // namespace m

--- a/opt/staticrelo/StaticRelo.cpp
+++ b/opt/staticrelo/StaticRelo.cpp
@@ -207,6 +207,7 @@ candidates_t build_candidates(
     // we could still move methods and not delete the class, but let's
     // simplify things for now.
     && m::can_delete<DexClass>()
+    && !m::is_seed<DexClass>()
     && !m::any_annos<DexClass>(
         m::as_type<DexAnnotation>(m::in<DexType>(dont_optimize_annos)));
 


### PR DESCRIPTION
ReDex does not respect `--keep`/`--seed` options.  It processes the input but does not check them in `StaticReloPass`.  This adds the check so problem classes such as in #30 can be worked around.