### PR TITLE
Make README header render larger than subheaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ReDex: An Android Bytecode Optimizer
-------------------------------------
+====================================
 
 ReDex is an Android bytecode (dex) optimizer originally developed at
 Facebook. It provides a framework for reading, writing, and analyzing .dex


### PR DESCRIPTION
"ReDex: An Android Bytecode Optimizer" was rendering smaller than "Quick Start Guide" on GitHub, which looks kind of weird.
