### PR TITLE
Validate keystore is present when `--sign` is used

### DIFF
--- a/redex.py
+++ b/redex.py
@@ -297,6 +297,18 @@ def copy_file_to_out_dir(tmp, apk_output_path, name, human_name, out_name):
     else:
         log('Skipping ' + human_name + ' copy, since no file found to copy')
 
+
+def validate_args(args):
+    if args.sign:
+        for arg_name in ['keystore', 'keyalias', 'keypass']:
+            if getattr(args, arg_name) is None:
+                raise argparse.ArgumentTypeError(
+                    'Could not find a suitable default for --{} and no value '
+                    'was provided.  This argument is required when --sign '
+                    'is used'.format(arg_name),
+                )
+
+
 def arg_parser(
         binary=None,
         config=None,
@@ -501,4 +513,5 @@ if __name__ == '__main__':
     except:
         pass
     args = arg_parser(**keys).parse_args()
+    validate_args(args)
     run_redex(args)


### PR DESCRIPTION
Summary: When default keystore is not present and `--sign` is passed to
Redex you'll get a type error when `jarsign` is called because `None`
values are provided for keystore and friends.  With this change the code
will exit early if keystore is not provided as an argument and the
default value turns out to be `None`.

Test plan:
```
$ env ANDROID_SDK=/Users/mareksapota/Library/Android/sdk/ redex --sign my.apk -o redex-my.apk
Error writing mapping file: No such file or directory
Traceback (most recent call last):
  File "/tmp/redex.9iiz1o/redex.py", line 504, in <module>
    run_redex(args)
  File "/tmp/redex.9iiz1o/redex.py", line 468, in run_redex
    args.keyalias, args.keypass)
  File "/tmp/redex.9iiz1o/redex.py", line 224, in create_output_apk
    stdout=sys.stderr)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 535, in check_call
    retcode = call(*popenargs, **kwargs)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 522, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 1335, in _execute_child
    raise child_exception
TypeError: execv() arg 2 must contain only strings

$ env ANDROID_SDK=/Users/mareksapota/Library/Android/sdk/ ~/src/redex/redex --sign my.apk -o redex-my.apk
Traceback (most recent call last):
  File "/tmp/redex.Nmbt8v/redex.py", line 516, in <module>
    validate_args(args)
  File "/tmp/redex.Nmbt8v/redex.py", line 309, in validate_args
    'is used'.format(arg_name),
argparse.ArgumentTypeError: Could not find a suitable default for --keystore and no value was provided.  This argument is required when --sign is used
```