### PR TITLE
Lower minimum requirement of boost library to 1.53

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,8 +19,8 @@ AM_PATH_PYTHON([3.0], [], [AC_MSG_ERROR([Redex requires python3])])
 
 # Checks for libraries.
 AX_PTHREAD
-AX_BOOST_BASE([1.54.0], [], [AC_MSG_ERROR(
-              [Please install boost >= 1.54 (including filesystem)])])
+AX_BOOST_BASE([1.53.0], [], [AC_MSG_ERROR(
+              [Please install boost >= 1.53 (including filesystem)])])
 AX_BOOST_FILESYSTEM
 AX_BOOST_SYSTEM
 AX_BOOST_REGEX


### PR DESCRIPTION
Currently the latest version of boost library publicly available for centos7 is 1.53 https://rpmfind.net/linux/rpm2html/search.php?query=boost-devel. I have built it against 1.53, and it works fine whereas obtaining boost-devel >= 1.54 is relatively difficult.