### PR TITLE
fix iteritems -> items

### DIFF
--- a/pyredex/logger.py
+++ b/pyredex/logger.py
@@ -64,7 +64,7 @@ def strip_trace_tag(env):
             trace.pop(ALL)
         else:
             trace_str = ''
-        trace_str += ','.join(k + ':' + str(v) for k, v in trace.iteritems())
+        trace_str += ','.join(k + ':' + str(v) for k, v in trace.items())
         env['TRACE'] = trace_str
     except KeyError:
         pass


### PR DESCRIPTION
fixed exception 
File "/private/tmp/redex.eNWbjc/pyredex/logger.py", line 65, in strip_trace_tag
    trace_str += ','.join(k + ':' + str(v) for k, v in trace.iteritems())
AttributeError: 'dict' object has no attribute 'iteritems'