### PR TITLE
Fix build with C++17

### DIFF
--- a/libredex/DexAnnotation.h
+++ b/libredex/DexAnnotation.h
@@ -389,7 +389,7 @@ class DexAnnotationSet : public Gatherable {
   }
   std::vector<DexAnnotation*>& get_annotations() { return m_annotations; }
   void add_annotation(DexAnnotation* anno) {
-    return m_annotations.emplace_back(anno);
+    m_annotations.emplace_back(anno);
   }
   void vencode(DexOutputIdx* dodx,
                std::vector<uint32_t>& asetout,


### PR DESCRIPTION
In C++17, `emplace_back` returns a reference to the new element instead
of void. This fixes a call where this results in returning a value from
a void-returning function.