### PR TITLE
A bunch of useful fixes

### DIFF
--- a/pyredex/unpacker.py
+++ b/pyredex/unpacker.py
@@ -6,6 +6,7 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 import hashlib
+import itertools
 import json
 import os
 import re
@@ -216,7 +217,7 @@ class Api21DexMode(BaseDexMode):
                                store=self._store_id,
                                dependencies=self._dependencies,
                                locator_store_id=locator_store_id)
-        for i in range(2, 100):
+        for i in itertools.count(2):
             dex_path = join(dex_dir, self._dex_prefix + '%d.dex' % i)
             if not isfile(dex_path):
                 break
@@ -298,7 +299,7 @@ class SubdirDexMode(BaseDexMode):
                                store=self._store_id,
                                dependencies=self._dependencies,
                                locator_store_id=locator_store_id)
-        for i in range(1, 100):
+        for i in itertools.count(1):
             oldpath = join(dex_dir, self._dex_prefix + '%d.dex' % (i + 1))
             dexpath = join(dex_dir, self._store_name + '-%d.dex' % i)
             if not isfile(oldpath):
@@ -431,7 +432,7 @@ class XZSDexMode(BaseDexMode):
                                    locator_store_id=locator_store_id)
 
         with open(concat_jar_path, 'wb') as concat_jar:
-            for i in range(1, 100):
+            for i in itertools.count(1):
                 oldpath = join(dex_dir, self._dex_prefix + '%d.dex' % (i + 1))
                 if not isfile(oldpath):
                     break

--- a/redex.py
+++ b/redex.py
@@ -34,6 +34,17 @@ import pyredex.unpacker as unpacker
 from pyredex.utils import abs_glob, make_temp_dir, remove_temp_dirs
 from pyredex.logger import log
 
+# See http://bugs.python.org/issue14315
+def patch_zip_file():
+    old_decode_extra = zipfile.ZipInfo._decodeExtra
+    def decodeExtra(self):
+        try:
+            old_decode_extra(self)
+        except struct.error:
+            pass
+    zipfile.ZipInfo._decodeExtra = decodeExtra
+patch_zip_file()
+
 timer = timeit.default_timer
 
 per_file_compression = {}

--- a/redex.py
+++ b/redex.py
@@ -233,16 +233,18 @@ def unzip_apk(apk, destination_directory):
         z.extractall(destination_directory)
 
 
-def zipalign(unaligned_apk_path, output_apk_path, ignore_zipalign):
+def zipalign(unaligned_apk_path, output_apk_path, ignore_zipalign, page_align):
     # Align zip and optionally perform good compression.
     try:
         zipalign = [join(find_android_build_tools(), 'zipalign')]
     except Exception:
         # We couldn't find zipalign via ANDROID_SDK.  Try PATH.
         zipalign = ['zipalign']
+    args = ['4', unaligned_apk_path, output_apk_path]
+    if page_align:
+        args = ['-p'] + args
     try:
-        subprocess.check_call(zipalign +
-                              ['4', unaligned_apk_path, output_apk_path])
+        subprocess.check_call(zipalign + args)
     except subprocess.CalledProcessError:
         print("Couldn't find zipalign. See README.md to resolve this.")
         if not ignore_zipalign:
@@ -252,7 +254,7 @@ def zipalign(unaligned_apk_path, output_apk_path, ignore_zipalign):
 
 
 def create_output_apk(extracted_apk_dir, output_apk_path, sign, keystore,
-        key_alias, key_password, ignore_zipalign):
+        key_alias, key_password, ignore_zipalign, page_align):
 
     # Remove old signature files
     for f in abs_glob(extracted_apk_dir, 'META-INF/*'):
@@ -293,7 +295,7 @@ def create_output_apk(extracted_apk_dir, output_apk_path, sign, keystore,
     if isfile(output_apk_path):
         os.remove(output_apk_path)
 
-    zipalign(unaligned_apk_path, output_apk_path, ignore_zipalign)
+    zipalign(unaligned_apk_path, output_apk_path, ignore_zipalign, page_align)
 
 
 def merge_proguard_maps(
@@ -464,6 +466,8 @@ Given an APK, produce a better APK!
     parser.add_argument('--gdb', action='store_true', help='Run redex binary in gdb')
     parser.add_argument('--ignore-zipalign', action='store_true', help='Ignore if zipalign is not found')
     parser.add_argument('--verify-none-mode', action='store_true', help='Enable verify-none mode on redex')
+    parser.add_argument('--page-align-libs', action='store_true',
+           help='Preserve 4k page alignment for uncompressed libs')
 
     return parser
 
@@ -632,7 +636,7 @@ def run_redex(args):
 
     log('Creating output apk')
     create_output_apk(extracted_apk_dir, args.out, args.sign, args.keystore,
-            args.keyalias, args.keypass, args.ignore_zipalign)
+            args.keyalias, args.keypass, args.ignore_zipalign, args.page_align_libs)
     log('Creating output APK finished in {:.2f} seconds'.format(
             timer() - repack_start_time))
     copy_file_to_out_dir(dex_dir, args.out, 'redex-line-number-map', 'line number map', 'redex-line-number-map')


### PR DESCRIPTION
Hey guys! Got some fixes, maybe you will find some of them worth merging.
1. Add an override for zip alignment bug.
It's and old bug with python being unable to read non-conforming zip archives, http://bugs.python.org/issue14315. Gradle seems to always generate such a file for apk, so it's impossible to use redex on systems with old python. Updating it may be difficult on old systems like Ubuntu 14.04 LTS, for example on CI build agents and so on. This fix allows to overcome this error on systems with bad python, while doing nothing on systems with the good one.
2. Align uncompressed so files for 4098 bytes.
Redexing breaks 4k alignment for uncompressed native libs (https://stackoverflow.com/a/44704840/6109012) because of the repackaging. Add the -p switch for zipalign that does exactly that - creates 4k alignment for .so's with "store" compression.
3. Fix hardcoded dex files limit to enable >100 dex files apk processing.
This was quite a critical bug: redex skips dex files with id grater then 100 when packaging apk. I.e. if you had an apk file with 120 dexes, then redex will produce a file only with first 100 of them, resulting in broken application.