### PR TITLE
Vcpkg mman dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@
 /redexdump
 /stamp-h1
 /test-driver
+/.vs/
+/build-cmake/

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ cmake .. -G Ninja
 
 On Windows, first, get `CMAKE_TOOLCHAIN_FILE` from the output of `"vcpkg integrate install"`, and then:
 ```
-cmake .. -G "Visual Studio 15 2017 Win64"`
- -DVCPKG_TARGET_TRIPLET=x64-windows-static`
+cmake .. -G "Visual Studio 15 2017 Win64"
+ -DVCPKG_TARGET_TRIPLET=x64-windows-static
  -DCMAKE_TOOLCHAIN_FILE="C:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake"
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Install necessary libraries with `x64-windows-static`:
 .\vcpkg install boost --triplet x64-windows-static
 .\vcpkg install zlib --triplet x64-windows-static
 .\vcpkg install jsoncpp --triplet x64-windows-static
+.\vcpkg install mman --triplet x64-windows-static
 ```
 
 ## Download, Build and Install

--- a/libresource/RedexResources.cpp
+++ b/libresource/RedexResources.cpp
@@ -18,7 +18,13 @@
 #include <boost/regex.hpp>
 #include <sstream>
 #include <string>
+
+#ifdef _MSC_VER
+#include <mman/sys/mman.h>
+#else Q_OS_LINUX
 #include <sys/mman.h>
+#endif
+
 #include <sys/stat.h>
 #include <unordered_set>
 #include <vector>


### PR DESCRIPTION
For Windows 10 (64-bit) Builds - "mman install" related changes:

-Added "/.vs/" and "/build-cmake/" folders to gitignore
-Added "vcpkg mman install" instruction to the README
-Added platform verification for mman header inclusion