### PR TITLE
added sparta/include dir to headers for cmake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ file(GLOB includes
         "liblocator"
         "libresource"
         "shared"
+        "sparta/include"
         )
 
 include_directories(


### PR DESCRIPTION
This commit adds the embedded `sparta/include` dir to the header searchpath
for cmake builds as a fix for errors locating `MonotonicFixpointIterator.h`
(and possibly other) includes.

Without this I see errors like below during build:

```
../libredex/CallGraph.h:15:10: fatal error: 'MonotonicFixpointIterator.h' file not found
```