### PR TITLE
add jemalloc and profiling util srcs to cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ file(GLOB_RECURSE redex_srcs
         "service/*.h"
         "opt/*.cpp"
         "opt/*.h"
+        "util/CommandProfiling.*"
+        "util/JemallocUtil.*"
         "util/Sha1.*"
         "shared/*.cpp"
         "shared/*.h"


### PR DESCRIPTION
This commit updates the cmake build script to include
`util/CommandProfiling` and `util/JemallocUtil` as a fix for
missing symbols when building with cmake.

These already appear in Makefile.am so I expect the cmake src list has
just fallen out of date.

I used `.*` to also include the headers in the source list for consistency
with `utils/Sha1.*` which was already present. All the other dirs
in that section just include `*.h` and `*.cpp` but I'm assuming you want to
avoid MallocDebug for normal builds.