### PR TITLE
Trying to export automake variables

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,10 +5,7 @@ SUBDIRS = . test
 ACLOCAL_AMFLAGS = -I m4
 AM_CXXFLAGS = --std=gnu++14 -O3 -Wall -g
 
-#
-# Include paths
-#
-AM_CPPFLAGS = \
+export REDEX_INCLUDE_FLAGS = \
 	-I$(top_srcdir)/liblocator \
 	-I$(top_srcdir)/libredex \
 	-I$(top_srcdir)/libresource \
@@ -81,99 +78,98 @@ AM_CPPFLAGS = \
 	-I/usr/include/jsoncpp
 
 #
+# Include paths
+#
+AM_CPPFLAGS = $(REDEX_INCLUDE_FLAGS)
+
+#
 # libredex: the optimizer's guts
 #
 noinst_LTLIBRARIES = libredex.la
 
-libredex_la_SOURCES = \
-	liblocator/locator.cpp \
-	libredex/AnnoUtils.cpp \
-	libredex/ApkManager.cpp \
-	libredex/CallGraph.cpp \
-	libredex/ClassHierarchy.cpp \
-	libredex/ConfigFiles.cpp \
-	libredex/Creators.cpp \
-	libredex/ControlFlow.cpp \
-	libredex/Debug.cpp \
-	libredex/DexAnnotation.cpp \
-	libredex/DexClass.cpp \
-	libredex/DexDebugInstruction.cpp \
-	libredex/DexEncoding.cpp \
-	libredex/DexIdx.cpp \
-	libredex/DexLoader.cpp \
-	libredex/DexInstruction.cpp \
-	libredex/DexMemberRefs.cpp \
-	libredex/DexOpcode.cpp \
-	libredex/DexOutput.cpp \
-	libredex/DexPosition.cpp \
-	libredex/DexStore.cpp \
-	libredex/DexUtil.cpp \
-	libredex/FieldOpTracker.cpp \
-	libredex/ImmutableSubcomponentAnalyzer.cpp \
-	libredex/Inliner.cpp \
-	libredex/InstructionLowering.cpp \
-	libredex/IRAssembler.cpp \
-	libredex/IRCode.cpp \
-	libredex/IRInstruction.cpp \
-	libredex/IRList.cpp \
-	libredex/IROpcode.cpp \
-	libredex/IRTypeChecker.cpp \
-	libredex/JarLoader.cpp \
-	libredex/Match.cpp \
-	libredex/MethodDevirtualizer.cpp \
-	libredex/Mutators.cpp \
-	libredex/OptData.cpp \
-	libredex/PassManager.cpp \
-	libredex/PassRegistry.cpp \
-	libredex/PluginRegistry.cpp \
-	libredex/PointsToSemantics.cpp \
-	libredex/PointsToSemanticsUtils.cpp \
-	libredex/PrintSeeds.cpp \
-	libredex/ProguardLexer.cpp \
-	libredex/ProguardMap.cpp \
-	libredex/ProguardMatcher.cpp \
-	libredex/ProguardParser.cpp \
-	libredex/ProguardPrintConfiguration.cpp \
-	libredex/ProguardRegex.cpp \
-	libredex/ProguardReporting.cpp \
-	libredex/ReachableClasses.cpp \
-	libredex/ReachableObjects.cpp \
-	libredex/RedexContext.cpp \
-	libredex/Resolver.cpp \
-	libredex/Show.cpp \
-	libredex/SimpleReflectionAnalysis.cpp \
-	libredex/Timer.cpp \
-	libredex/Trace.cpp \
-	libredex/Transform.cpp \
-	libredex/IRTypeChecker.cpp \
-	libredex/TypeSystem.cpp \
-	libredex/Vinfo.cpp \
-	libredex/VirtualScope.cpp \
-	libredex/Warning.cpp \
-	libresource/FileMap.cpp \
-	libresource/RedexResources.cpp \
-	libresource/ResourceTypes.cpp \
-	libresource/Serialize.cpp \
-	libresource/SharedBuffer.cpp \
-	libresource/Static.cpp \
-	libresource/String16.cpp \
-	libresource/String8.cpp \
-	libresource/TypeWrappers.cpp \
-	libresource/Unicode.cpp \
-	libresource/VectorImpl.cpp \
-	shared/DexDefs.cpp \
-	shared/file-utils.cpp \
-	util/CommandProfiling.cpp \
-	util/JemallocUtil.cpp \
-	util/Sha1.cpp
+export LIBREDEX_CPP_FILES = \
+	$(top_srcdir)/liblocator/locator.cpp \
+	$(top_srcdir)/libredex/AnnoUtils.cpp \
+	$(top_srcdir)/libredex/ApkManager.cpp \
+	$(top_srcdir)/libredex/CallGraph.cpp \
+	$(top_srcdir)/libredex/ClassHierarchy.cpp \
+	$(top_srcdir)/libredex/ConfigFiles.cpp \
+	$(top_srcdir)/libredex/Creators.cpp \
+	$(top_srcdir)/libredex/ControlFlow.cpp \
+	$(top_srcdir)/libredex/Debug.cpp \
+	$(top_srcdir)/libredex/DexAnnotation.cpp \
+	$(top_srcdir)/libredex/DexClass.cpp \
+	$(top_srcdir)/libredex/DexDebugInstruction.cpp \
+	$(top_srcdir)/libredex/DexEncoding.cpp \
+	$(top_srcdir)/libredex/DexIdx.cpp \
+	$(top_srcdir)/libredex/DexLoader.cpp \
+	$(top_srcdir)/libredex/DexInstruction.cpp \
+	$(top_srcdir)/libredex/DexMemberRefs.cpp \
+	$(top_srcdir)/libredex/DexOpcode.cpp \
+	$(top_srcdir)/libredex/DexOutput.cpp \
+	$(top_srcdir)/libredex/DexPosition.cpp \
+	$(top_srcdir)/libredex/DexStore.cpp \
+	$(top_srcdir)/libredex/DexUtil.cpp \
+	$(top_srcdir)/libredex/FieldOpTracker.cpp \
+	$(top_srcdir)/libredex/ImmutableSubcomponentAnalyzer.cpp \
+	$(top_srcdir)/libredex/Inliner.cpp \
+	$(top_srcdir)/libredex/InstructionLowering.cpp \
+	$(top_srcdir)/libredex/IRAssembler.cpp \
+	$(top_srcdir)/libredex/IRCode.cpp \
+	$(top_srcdir)/libredex/IRInstruction.cpp \
+	$(top_srcdir)/libredex/IRList.cpp \
+	$(top_srcdir)/libredex/IROpcode.cpp \
+	$(top_srcdir)/libredex/IRTypeChecker.cpp \
+	$(top_srcdir)/libredex/JarLoader.cpp \
+	$(top_srcdir)/libredex/Match.cpp \
+	$(top_srcdir)/libredex/MethodDevirtualizer.cpp \
+	$(top_srcdir)/libredex/Mutators.cpp \
+	$(top_srcdir)/libredex/OptData.cpp \
+	$(top_srcdir)/libredex/PassManager.cpp \
+	$(top_srcdir)/libredex/PassRegistry.cpp \
+	$(top_srcdir)/libredex/PluginRegistry.cpp \
+	$(top_srcdir)/libredex/PointsToSemantics.cpp \
+	$(top_srcdir)/libredex/PointsToSemanticsUtils.cpp \
+	$(top_srcdir)/libredex/PrintSeeds.cpp \
+	$(top_srcdir)/libredex/ProguardLexer.cpp \
+	$(top_srcdir)/libredex/ProguardMap.cpp \
+	$(top_srcdir)/libredex/ProguardMatcher.cpp \
+	$(top_srcdir)/libredex/ProguardParser.cpp \
+	$(top_srcdir)/libredex/ProguardPrintConfiguration.cpp \
+	$(top_srcdir)/libredex/ProguardRegex.cpp \
+	$(top_srcdir)/libredex/ProguardReporting.cpp \
+	$(top_srcdir)/libredex/ReachableClasses.cpp \
+	$(top_srcdir)/libredex/ReachableObjects.cpp \
+	$(top_srcdir)/libredex/RedexContext.cpp \
+	$(top_srcdir)/libredex/Resolver.cpp \
+	$(top_srcdir)/libredex/Show.cpp \
+	$(top_srcdir)/libredex/SimpleReflectionAnalysis.cpp \
+	$(top_srcdir)/libredex/Timer.cpp \
+	$(top_srcdir)/libredex/Trace.cpp \
+	$(top_srcdir)/libredex/Transform.cpp \
+	$(top_srcdir)/libredex/IRTypeChecker.cpp \
+	$(top_srcdir)/libredex/TypeSystem.cpp \
+	$(top_srcdir)/libredex/Vinfo.cpp \
+	$(top_srcdir)/libredex/VirtualScope.cpp \
+	$(top_srcdir)/libredex/Warning.cpp \
+	$(top_srcdir)/libresource/FileMap.cpp \
+	$(top_srcdir)/libresource/RedexResources.cpp \
+	$(top_srcdir)/libresource/ResourceTypes.cpp \
+	$(top_srcdir)/libresource/Serialize.cpp \
+	$(top_srcdir)/libresource/SharedBuffer.cpp \
+	$(top_srcdir)/libresource/Static.cpp \
+	$(top_srcdir)/libresource/String16.cpp \
+	$(top_srcdir)/libresource/String8.cpp \
+	$(top_srcdir)/libresource/TypeWrappers.cpp \
+	$(top_srcdir)/libresource/Unicode.cpp \
+	$(top_srcdir)/libresource/VectorImpl.cpp \
+	$(top_srcdir)/shared/DexDefs.cpp \
+	$(top_srcdir)/shared/file-utils.cpp \
+	$(top_srcdir)/util/CommandProfiling.cpp \
+	$(top_srcdir)/util/JemallocUtil.cpp \
+	$(top_srcdir)/util/Sha1.cpp
 
-libredex_la_LIBADD = \
-	$(BOOST_FILESYSTEM_LIB) \
-	$(BOOST_SYSTEM_LIB) \
-	$(BOOST_REGEX_LIB) \
-	$(BOOST_IOSTREAMS_LIB) \
-	$(BOOST_THREAD_LIB) \
-	-lpthread
+libredex_la_SOURCES = $(LIBREDEX_CPP_FILES)
 
 #
 # redex-all: the main executable
@@ -181,110 +177,118 @@ libredex_la_LIBADD = \
 bin_PROGRAMS = redexdump
 noinst_PROGRAMS = redex-all
 
-redex_all_SOURCES = \
-	libredex/DexAsm.cpp \
-	opt/access-marking/AccessMarking.cpp \
-	opt/add_redex_txt_to_apk/AddRedexTxtToApk.cpp \
-	opt/analysis_ref_graph/ReferenceGraphCreator.cpp \
-	opt/annokill/AnnoKill.cpp \
-	opt/basic-block/BasicBlockProfile.cpp \
-	opt/bridge/Bridge.cpp \
-	opt/check_breadcrumbs/CheckBreadcrumbs.cpp \
-	opt/constant-propagation/ConstantPropagation.cpp \
-	opt/constant-propagation/ConstantPropagationRuntimeAssert.cpp \
-	opt/constant-propagation/ConstantPropagationTransform.cpp \
-	opt/constant-propagation/IPConstantPropagation.cpp \
-	opt/copy-propagation/AliasedRegisters.cpp \
-	opt/copy-propagation/CopyPropagationPass.cpp \
-	opt/dead-code-elimination/DeadCodeEliminationPass.cpp \
-	opt/dead-code-elimination/SideEffectSummary.cpp \
-	opt/dead-code-elimination/UsedVarsAnalysis.cpp \
-	opt/dedup_blocks/DedupBlocksPass.cpp \
-	opt/delinit/DelInit.cpp \
-	opt/delsuper/DelSuper.cpp \
-	opt/final_inline/FinalInline.cpp \
-	opt/final_inline/FinalInlineV2.cpp \
-	opt/hotness-score/HotnessScore.cpp \
-	opt/inlineinit/InlineInit.cpp \
-	opt/instrument/Instrument.cpp \
-	opt/interdex/DexStructure.cpp \
-	opt/interdex/InterDex.cpp \
-	opt/interdex/InterDexPass.cpp \
-	opt/local-dce/LocalDce.cpp \
-	opt/obfuscate/Obfuscate.cpp \
-	opt/obfuscate/ObfuscateUtils.cpp \
-	opt/obfuscate/VirtualRenamer.cpp \
-	opt/original_name/OriginalNamePass.cpp \
-	opt/outliner/Outliner.cpp \
-	opt/peephole/Peephole.cpp \
-	opt/peephole/RedundantCheckCastRemover.cpp \
-	opt/print-members/PrintMembers.cpp \
-	opt/reachability_graph/ReachabilityGraphPrinter.cpp \
-	opt/rebindrefs/ReBindRefs.cpp \
-	opt/regalloc/GraphColoring.cpp \
-	opt/regalloc/Interference.cpp \
-	opt/regalloc/RegAlloc.cpp \
-	opt/regalloc/RegisterType.cpp \
-	opt/regalloc/Split.cpp \
-	opt/regalloc/VirtualRegistersFile.cpp \
-	opt/remove-builders/RemoveBuilders.cpp \
-	opt/remove-builders/RemoveBuildersHelper.cpp \
-	opt/remove-unreachable/RemoveUnreachable.cpp \
-	opt/remove-unread-fields/RemoveUnreadFields.cpp \
-	opt/remove_empty_classes/RemoveEmptyClasses.cpp \
-	opt/remove_gotos/RemoveGotos.cpp \
-	opt/remove_unused_args/RemoveUnusedArgs.cpp \
-	opt/renameclasses/RenameClasses.cpp \
-	opt/renameclasses/RenameClassesV2.cpp \
-	opt/reorder-interfaces/ReorderInterfaces.cpp \
-	opt/shorten-srcstrings/Shorten.cpp \
-	opt/simpleinline/Deleter.cpp \
-	opt/simpleinline/SimpleInline.cpp \
-	opt/singleimpl/SingleImpl.cpp \
-	opt/singleimpl/SingleImplAnalyze.cpp \
-	opt/singleimpl/SingleImplOptimize.cpp \
-	opt/singleimpl/SingleImplStats.cpp \
-	opt/singleimpl/SingleImplUtil.cpp \
-	opt/simplify_cfg/SimplifyCFG.cpp \
-	opt/static-sink/StaticSink.cpp \
-	opt/staticrelo/StaticRelo.cpp \
-	opt/staticrelo/StaticReloV2.cpp \
-	opt/string_concatenator/StringConcatenator.cpp \
-	opt/string_simplification/StringIterator.cpp \
-	opt/string_simplification/StringSimplification.cpp \
-	opt/strip-debug-info/StripDebugInfo.cpp \
-	opt/synth/Synth.cpp \
-	opt/test_cfg/TestCFG.cpp \
-	opt/track_resources/TrackResources.cpp \
-	opt/unreferenced_interfaces/UnreferencedInterfaces.cpp \
-	opt/unterface/Unterface.cpp \
-	opt/unterface/UnterfaceOpt.cpp \
-	opt/verifier/Verifier.cpp \
-	opt/virtual_scope/MethodDevirtualizationPass.cpp \
-	service/constant-propagation/ConstantEnvironment.cpp \
-	service/constant-propagation/ConstantPropagationAnalysis.cpp \
-	service/constant-propagation/ConstantPropagationWholeProgramState.cpp \
-	service/constant-propagation/IPConstantPropagationAnalysis.cpp \
-	service/constant-propagation/ObjectDomain.cpp \
-	service/constant-propagation/SignDomain.cpp \
-	service/dataflow/LiveRange.cpp \
-	service/escape-analysis/LocalPointersAnalysis.cpp \
-	service/method-dedup/ConstantLifting.cpp \
-	service/method-dedup/MethodDedup.cpp \
-	service/method-dedup/TypeTags.cpp \
-	service/reference-update/MethodReference.cpp \
-	service/reference-update/TypeReference.cpp \
-	service/switch-dispatch/SwitchDispatch.cpp \
-	tools/redex-all/main.cpp
+export REDEX_OPT_CPP_FILES = \
+	$(top_srcdir)/libredex/DexAsm.cpp \
+	$(top_srcdir)/opt/access-marking/AccessMarking.cpp \
+	$(top_srcdir)/opt/add_redex_txt_to_apk/AddRedexTxtToApk.cpp \
+	$(top_srcdir)/opt/analysis_ref_graph/ReferenceGraphCreator.cpp \
+	$(top_srcdir)/opt/annokill/AnnoKill.cpp \
+	$(top_srcdir)/opt/basic-block/BasicBlockProfile.cpp \
+	$(top_srcdir)/opt/bridge/Bridge.cpp \
+	$(top_srcdir)/opt/check_breadcrumbs/CheckBreadcrumbs.cpp \
+	$(top_srcdir)/opt/constant-propagation/ConstantPropagation.cpp \
+	$(top_srcdir)/opt/constant-propagation/ConstantPropagationRuntimeAssert.cpp \
+	$(top_srcdir)/opt/constant-propagation/ConstantPropagationTransform.cpp \
+	$(top_srcdir)/opt/constant-propagation/IPConstantPropagation.cpp \
+	$(top_srcdir)/opt/copy-propagation/AliasedRegisters.cpp \
+	$(top_srcdir)/opt/copy-propagation/CopyPropagationPass.cpp \
+	$(top_srcdir)/opt/dead-code-elimination/DeadCodeEliminationPass.cpp \
+	$(top_srcdir)/opt/dead-code-elimination/SideEffectSummary.cpp \
+	$(top_srcdir)/opt/dead-code-elimination/UsedVarsAnalysis.cpp \
+	$(top_srcdir)/opt/dedup_blocks/DedupBlocksPass.cpp \
+	$(top_srcdir)/opt/delinit/DelInit.cpp \
+	$(top_srcdir)/opt/delsuper/DelSuper.cpp \
+	$(top_srcdir)/opt/final_inline/FinalInline.cpp \
+	$(top_srcdir)/opt/final_inline/FinalInlineV2.cpp \
+	$(top_srcdir)/opt/hotness-score/HotnessScore.cpp \
+	$(top_srcdir)/opt/inlineinit/InlineInit.cpp \
+	$(top_srcdir)/opt/instrument/Instrument.cpp \
+	$(top_srcdir)/opt/interdex/DexStructure.cpp \
+	$(top_srcdir)/opt/interdex/InterDex.cpp \
+	$(top_srcdir)/opt/interdex/InterDexPass.cpp \
+	$(top_srcdir)/opt/local-dce/LocalDce.cpp \
+	$(top_srcdir)/opt/obfuscate/Obfuscate.cpp \
+	$(top_srcdir)/opt/obfuscate/ObfuscateUtils.cpp \
+	$(top_srcdir)/opt/obfuscate/VirtualRenamer.cpp \
+	$(top_srcdir)/opt/original_name/OriginalNamePass.cpp \
+	$(top_srcdir)/opt/outliner/Outliner.cpp \
+	$(top_srcdir)/opt/peephole/Peephole.cpp \
+	$(top_srcdir)/opt/peephole/RedundantCheckCastRemover.cpp \
+	$(top_srcdir)/opt/print-members/PrintMembers.cpp \
+	$(top_srcdir)/opt/reachability_graph/ReachabilityGraphPrinter.cpp \
+	$(top_srcdir)/opt/rebindrefs/ReBindRefs.cpp \
+	$(top_srcdir)/opt/regalloc/GraphColoring.cpp \
+	$(top_srcdir)/opt/regalloc/Interference.cpp \
+	$(top_srcdir)/opt/regalloc/RegAlloc.cpp \
+	$(top_srcdir)/opt/regalloc/RegisterType.cpp \
+	$(top_srcdir)/opt/regalloc/Split.cpp \
+	$(top_srcdir)/opt/regalloc/VirtualRegistersFile.cpp \
+	$(top_srcdir)/opt/remove-builders/RemoveBuilders.cpp \
+	$(top_srcdir)/opt/remove-builders/RemoveBuildersHelper.cpp \
+	$(top_srcdir)/opt/remove-unreachable/RemoveUnreachable.cpp \
+	$(top_srcdir)/opt/remove-unread-fields/RemoveUnreadFields.cpp \
+	$(top_srcdir)/opt/remove_empty_classes/RemoveEmptyClasses.cpp \
+	$(top_srcdir)/opt/remove_gotos/RemoveGotos.cpp \
+	$(top_srcdir)/opt/remove_unused_args/RemoveUnusedArgs.cpp \
+	$(top_srcdir)/opt/renameclasses/RenameClasses.cpp \
+	$(top_srcdir)/opt/renameclasses/RenameClassesV2.cpp \
+	$(top_srcdir)/opt/reorder-interfaces/ReorderInterfaces.cpp \
+	$(top_srcdir)/opt/shorten-srcstrings/Shorten.cpp \
+	$(top_srcdir)/opt/simpleinline/Deleter.cpp \
+	$(top_srcdir)/opt/simpleinline/SimpleInline.cpp \
+	$(top_srcdir)/opt/singleimpl/SingleImpl.cpp \
+	$(top_srcdir)/opt/singleimpl/SingleImplAnalyze.cpp \
+	$(top_srcdir)/opt/singleimpl/SingleImplOptimize.cpp \
+	$(top_srcdir)/opt/singleimpl/SingleImplStats.cpp \
+	$(top_srcdir)/opt/singleimpl/SingleImplUtil.cpp \
+	$(top_srcdir)/opt/simplify_cfg/SimplifyCFG.cpp \
+	$(top_srcdir)/opt/static-sink/StaticSink.cpp \
+	$(top_srcdir)/opt/staticrelo/StaticRelo.cpp \
+	$(top_srcdir)/opt/staticrelo/StaticReloV2.cpp \
+	$(top_srcdir)/opt/string_concatenator/StringConcatenator.cpp \
+	$(top_srcdir)/opt/string_simplification/StringIterator.cpp \
+	$(top_srcdir)/opt/string_simplification/StringSimplification.cpp \
+	$(top_srcdir)/opt/strip-debug-info/StripDebugInfo.cpp \
+	$(top_srcdir)/opt/synth/Synth.cpp \
+	$(top_srcdir)/opt/test_cfg/TestCFG.cpp \
+	$(top_srcdir)/opt/track_resources/TrackResources.cpp \
+	$(top_srcdir)/opt/unreferenced_interfaces/UnreferencedInterfaces.cpp \
+	$(top_srcdir)/opt/unterface/Unterface.cpp \
+	$(top_srcdir)/opt/unterface/UnterfaceOpt.cpp \
+	$(top_srcdir)/opt/verifier/Verifier.cpp \
+	$(top_srcdir)/opt/virtual_scope/MethodDevirtualizationPass.cpp \
+	$(top_srcdir)/service/constant-propagation/ConstantEnvironment.cpp \
+	$(top_srcdir)/service/constant-propagation/ConstantPropagationAnalysis.cpp \
+	$(top_srcdir)/service/constant-propagation/ConstantPropagationWholeProgramState.cpp \
+	$(top_srcdir)/service/constant-propagation/IPConstantPropagationAnalysis.cpp \
+	$(top_srcdir)/service/constant-propagation/ObjectDomain.cpp \
+	$(top_srcdir)/service/constant-propagation/SignDomain.cpp \
+	$(top_srcdir)/service/dataflow/LiveRange.cpp \
+	$(top_srcdir)/service/escape-analysis/LocalPointersAnalysis.cpp \
+	$(top_srcdir)/service/method-dedup/ConstantLifting.cpp \
+	$(top_srcdir)/service/method-dedup/MethodDedup.cpp \
+	$(top_srcdir)/service/method-dedup/TypeTags.cpp \
+	$(top_srcdir)/service/reference-update/MethodReference.cpp \
+	$(top_srcdir)/service/reference-update/TypeReference.cpp \
+	$(top_srcdir)/service/switch-dispatch/SwitchDispatch.cpp \
+	$(top_srcdir)/tools/redex-all/main.cpp
 
-redex_all_LDADD = \
-	libredex.la \
+redex_all_SOURCES = $(REDEX_OPT_CPP_FILES)
+
+export REDEX_LIBS = \
 	$(BOOST_FILESYSTEM_LIB) \
 	$(BOOST_SYSTEM_LIB) \
 	$(BOOST_REGEX_LIB) \
+	$(BOOST_IOSTREAMS_LIB) \
 	$(BOOST_PROGRAM_OPTIONS_LIB) \
 	$(BOOST_THREAD_LIB) \
-	-lpthread \
+	-lpthread
+
+libredex_la_LIBADD = $(REDEX_LIBS)
+
+redex_all_LDADD = \
+	libredex.la \
+	$(REDEX_LIBS) \
 	-ldl
 
 redex_all_LDFLAGS = \
@@ -320,3 +324,12 @@ PYTHON_SRCS := redex.py \
 
 redex: redex-all $(PYTHON_SRCS)
 	$(srcdir)/bundle-redex.sh
+
+debug_print:
+	echo $(AM_CPPFLAGS) >/dev/null
+	echo ''
+	echo $(libredex_la_SOURCES) >/dev/null
+	echo ''
+	echo $(redex_all_SOURCES) >/dev/null
+	echo ''
+	echo $(libredex_la_LIBADD) >/dev/null

--- a/test/integ/Makefile.am
+++ b/test/integ/Makefile.am
@@ -1,39 +1,10 @@
+# TODO: finish including all the tests
+# TODO: Include all redex source cpp files
+
 AM_CXXFLAGS = --std=gnu++14
 AM_CPPFLAGS = \
 	-I$(top_srcdir)/test/googletest-release-1.7.0/include \
-	-I$(top_srcdir)/liblocator \
-	-I$(top_srcdir)/libredex \
-	-I$(top_srcdir)/libresource \
-	-I$(top_srcdir)/libresource/android \
-	-I$(top_srcdir)/libresource/androidfw \
-	-I$(top_srcdir)/libresource/cutils \
-	-I$(top_srcdir)/libresource/system \
-	-I$(top_srcdir)/libresource/utils \
-	-I$(top_srcdir)/opt \
-	-I$(top_srcdir)/opt/all-static \
-	-I$(top_srcdir)/opt/annokill \
-	-I$(top_srcdir)/opt/bridge \
-	-I$(top_srcdir)/opt/constant_propagation \
-	-I$(top_srcdir)/opt/delinit \
-	-I$(top_srcdir)/opt/delsuper \
-	-I$(top_srcdir)/opt/final_inline \
-	-I$(top_srcdir)/opt/interdex \
-	-I$(top_srcdir)/opt/local-dce \
-	-I$(top_srcdir)/opt/peephole \
-	-I$(top_srcdir)/opt/rebindrefs \
-	-I$(top_srcdir)/opt/remove_empty_classes \
-	-I$(top_srcdir)/opt/renameclasses \
-	-I$(top_srcdir)/opt/shorten-srcstrings \
-	-I$(top_srcdir)/opt/simpleinline \
-	-I$(top_srcdir)/opt/singleimpl \
-	-I$(top_srcdir)/opt/static-sink \
-	-I$(top_srcdir)/opt/staticrelo \
-	-I$(top_srcdir)/opt/synth \
-	-I$(top_srcdir)/opt/track_resources \
-	-I$(top_srcdir)/opt/unterface \
-	-I$(top_srcdir)/tools/redex-all \
-	-I$(top_srcdir)/util \
-	-I/usr/include/jsoncpp
+	$(REDEX_INCLUDE_FLAGS)
 
 TESTS = \
 	synth_test \
@@ -61,34 +32,41 @@ EXTRA_constant_propagation_test_DEPENDENCIES = constant-propagation-test-class.d
 
 check_PROGRAMS = $(TESTS)
 
+JAVA_BIN = `/usr/libexec/java_home -v 1.7`/bin
+
 synth-test-class.jar: Alpha.java SynthTest.java
 	mkdir -p synth-test-class
-	javac -d synth-test-class $^
-	jar cf $@ -C synth-test-class .
+	$(JAVA_BIN)/javac -version
+	$(JAVA_BIN)/javac -d synth-test-class $^
+	$(JAVA_BIN)/jar cf $@ -C synth-test-class .
 
 synth-test-class.dex: synth-test-class.jar
 	dx --dex --output=$@ $^
 
 empty-classes-test-class.jar: EmptyClasses.java EmptyClassesTest.java
 	mkdir -p empty-classes-test-class
-	javac -d empty-classes-test-class $^
-	jar cf $@ -C empty-classes-test-class .
+	$(JAVA_BIN)/javac -d empty-classes-test-class $^
+	$(JAVA_BIN)/jar cf $@ -C empty-classes-test-class .
 
 empty-classes-test-class.dex: empty-classes-test-class.jar
 	dx --dex --output=$@ $^
 
 propagation-test-class.jar: Propagation.java
 	mkdir -p propagation-test-class
-	javac -d propagation-test-class $^
-	jar cf $@ -C propagation-test-class .
+	$(JAVA_BIN)/javac -d propagation-test-class $^
+	$(JAVA_BIN)/jar cf $@ -C propagation-test-class .
 
 propagation-test-class.dex: propagation-test-class.jar
 	dx --dex --output=$@ $^
 
 constant-propagation-test-class.jar: ConstantPropagation.java
 	mkdir -p constant-propagation-test-class
-	javac -d constant-propagation-test-class $^
-	jar cf $@ -C constant-propagation-test-class .
+	$(JAVA_BIN)/javac -d constant-propagation-test-class $^
+	$(JAVA_BIN)/jar cf $@ -C constant-propagation-test-class .
 
 constant-propagation-test-class.dex: constant-propagation-test-class.jar
 	dx --dex --output=$@ $^
+
+clean-local:
+	rm -rf *.dex
+	rm -rf *.jar

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -1,39 +1,10 @@
+# TODO: finish including all the tests
+# TODO: Include all redex source cpp files
+
 AM_CXXFLAGS = --std=gnu++14
 AM_CPPFLAGS = \
 	-I$(top_srcdir)/test/googletest-release-1.7.0/include \
-	-I$(top_srcdir)/liblocator \
-	-I$(top_srcdir)/libredex \
-	-I$(top_srcdir)/libresource \
-	-I$(top_srcdir)/libresource/android \
-	-I$(top_srcdir)/libresource/androidfw \
-	-I$(top_srcdir)/libresource/cutils \
-	-I$(top_srcdir)/libresource/system \
-	-I$(top_srcdir)/libresource/utils \
-	-I$(top_srcdir)/opt \
-	-I$(top_srcdir)/opt/all-static \
-	-I$(top_srcdir)/opt/annokill \
-	-I$(top_srcdir)/opt/bridge \
-	-I$(top_srcdir)/opt/constant_propagation \
-	-I$(top_srcdir)/opt/delinit \
-	-I$(top_srcdir)/opt/delsuper \
-	-I$(top_srcdir)/opt/final_inline \
-	-I$(top_srcdir)/opt/interdex \
-	-I$(top_srcdir)/opt/local-dce \
-	-I$(top_srcdir)/opt/peephole \
-	-I$(top_srcdir)/opt/rebindrefs \
-	-I$(top_srcdir)/opt/remove_empty_classes \
-	-I$(top_srcdir)/opt/remove_unused_args \
-	-I$(top_srcdir)/opt/renameclasses \
-	-I$(top_srcdir)/opt/shorten-srcstrings \
-	-I$(top_srcdir)/opt/simpleinline \
-	-I$(top_srcdir)/opt/singleimpl \
-	-I$(top_srcdir)/opt/static-sink \
-	-I$(top_srcdir)/opt/staticrelo \
-	-I$(top_srcdir)/opt/synth \
-	-I$(top_srcdir)/opt/unterface \
-	-I$(top_srcdir)/tools/redex-all \
-	-I$(top_srcdir)/util \
-	-I/usr/include/jsoncpp
+	$(REDEX_INCLUDE_FLAGS)
 
 TESTS = \
 	config_parser_test \


### PR DESCRIPTION
Not ready to merge this. It's not working yet.

I'm seeking feedback and help on how to export variables from the top level `Makefile.am` into the `test/unit` and `test/integ` `Makefile.am`s. This is part of a follow-up to issue #310 

If you check this out then attempt to build redex, it fails:

```
$ autoreconf -ivf && ./configure && make -j4
...
	g++ -DPACKAGE_NAME=\"redex\" -DPACKAGE_TARNAME=\"redex\" -DPACKAGE_VERSION=\"1.0\" -DPACKAGE_STRING=\"redex\ 1.0\" -DPACKAGE_BUGREPORT=\"not-valid-yet@fb.com\" -DPACKAGE_URL=\"\" -DPACKAGE=\"redex\" -DVERSION=\"1.0\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DPACKAGE=\"redex\" -DVERSION=\"1.0\" -DHAVE_PTHREAD_PRIO_INHERIT=1 -DHAVE_PTHREAD=1 -DHAVE_BOOST=/\*\*/ -DHAVE_BOOST_FILESYSTEM=/\*\*/ -DHAVE_BOOST_SYSTEM=/\*\*/ -DHAVE_BOOST_REGEX=/\*\*/ -DHAVE_BOOST_PROGRAM_OPTIONS=/\*\*/ -DHAVE_BOOST_IOSTREAMS=/\*\*/ -DHAVE_BOOST_THREAD=/\*\*/ -DHAVE_LIBZ=1 -DHAVE_LIBJSONCPP=1 -DHAVE_ARPA_INET_H=1 -DHAVE_FCNTL_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_MEMORY_H=1 -DHAVE_NETINET_IN_H=1 -DHAVE_STDDEF_H=1 -DHAVE_STDINT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_SYS_TIME_H=1 -DHAVE_UNISTD_H=1 -DHAVE__BOOL=1 -DHAVE_STDLIB_H=1 -DHAVE_MALLOC=1 -DHAVE_STDLIB_H=1 -DHAVE_UNISTD_H=1 -DHAVE_SYS_PARAM_H=1 -DHAVE_GETPAGESIZE=1 -DHAVE_MMAP=1 -DHAVE_STDLIB_H=1 -DHAVE_REALLOC=1 -DHAVE_CLOCK_GETTIME=1 -DHAVE_GETTIMEOFDAY=1 -DHAVE_MEMMOVE=1 -DHAVE_MEMSET=1 -DHAVE_MUNMAP=1 -DHAVE_REGCOMP=1 -DHAVE_STRCHR=1 -DHAVE_STRDUP=1 -DHAVE_STRERROR=1 -DHAVE_STRRCHR=1 -DHAVE_STRSTR=1 -DHAVE_STRTOL=1 -I.  -I./liblocator -I./libredex -I./libresource -I./libresource/android -I./libresource/androidfw -I./libresource/cutils -I./libresource/system -I./libresource/utils -I./opt -I./opt/access-marking -I./opt/add_redex_txt_to_apk -I./opt/analysis_ref_graph -I./opt/annoclasskill -I./opt/annokill -I./opt/basic-block -I./opt/bridge -I./opt/check_breadcrumbs -I./opt/constant-propagation -I./opt/dead-code-elimination -I./opt/dedup_blocks -I./opt/delinit -I./opt/delsuper -I./opt/final_inline -I./opt/hotness-score -I./opt/inlineinit -I./opt/instrument -I./opt/interdex -I./opt/local-dce -I./opt/obfuscate -I./opt/original_name -I./opt/outliner -I./opt/peephole -I./opt/print-members -I./opt/rebindrefs -I./opt/redundant_move_elimination -I./opt/regalloc -I./opt/remove-builders -I./opt/remove-unreachable -I./opt/remove_empty_classes -I./opt/remove_gotos -I./opt/remove_unused_args -I./opt/renameclasses -I./opt/reorder-interfaces -I./opt/shorten-srcstrings -I./opt/simpleinline -I./opt/singleimpl -I./opt/static-sink -I./opt/staticrelo -I./opt/string_concatenator -I./opt/string_simplification -I./opt/strip-debug-info -I./opt/synth -I./opt/test_cfg -I./opt/track_resources -I./opt/unreferenced_interfaces -I./opt/unterface -I./opt/verifier -I./opt/virtual_scope -I./service/constant-propagation -I./service/dataflow -I./service/escape-analysis -I./service/method-dedup -I./service/reference-update -I./service/switch-dispatch -I./shared -I./sparta/include -I./tools/common -I./tools/redexdump -I./util -I/usr/include/jsoncpp  --std=gnu++14 -O3 -Wall -g  -MT tools/common/DexCommon.o -MD -MP -MF $depbase.Tpo -c -o tools/common/DexCommon.o tools/common/DexCommon.cpp &&\
	mv -f $depbase.Tpo $depbase.Po
libtool: link: ar cru .libs/libredex.a
ar: no archive members specified
usage:  ar -d [-TLsv] archive file ...
	ar -m [-TLsv] archive file ...
	ar -m [-abiTLsv] position archive file ...
	ar -p [-TLsv] archive [file ...]
	ar -q [-cTLsv] archive file ...
	ar -r [-cuTLsv] archive file ...
	ar -r [-abciuTLsv] position archive file ...
	ar -t [-TLsv] archive [file ...]
	ar -x [-ouTLsv] archive [file ...]
make[1]: *** [libredex.la] Error 1
make[1]: *** Waiting for unfinished jobs....
make: *** [all-recursive] Error 1
```

I think it fails because the user variables I'm creating (like `REDEX_INCLUDE_FLAGS`) aren't defined in the generated Makefile until after they're needed :(