### PR TITLE
Create ReDex binary with dependencies statically linked

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,16 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif ()
 
+if(NOT BUILD_TYPE)
+    set(BUILD_TYPE Shared)
+endif ()
+
+if(BUILD_TYPE STREQUAL Static)
+    set(ENABLE_STATIC ON CACHE BOOL "" FORCE)
+elseif (BUILD_TYPE STREQUAL Shared)
+    set(ENABLE_STATIC OFF CACHE BOOL "" FORCE)
+endif ()
+
 set_common_cxx_flags_for_redex()
 add_dependent_packages_for_redex()
 
@@ -69,7 +79,7 @@ add_executable(redex-all ${redex_all_srcs})
 
 target_link_libraries(redex-all
         ${Boost_LIBRARIES}
-        ${JSONCPP_LIBRARY}
+        ${REDEX_JSONCPP_LIBRARY}
         ${ZLIB_LIBRARIES}
         redex
         resource

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ add_executable(redex-all ${redex_all_srcs})
 target_link_libraries(redex-all
         ${Boost_LIBRARIES}
         ${REDEX_JSONCPP_LIBRARY}
-        ${ZLIB_LIBRARIES}
+        ${REDEX_ZLIB_LIBRARY}
         redex
         resource
         )

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ If you prefer the ninja build system:
 cmake .. -G Ninja
 ```
 
+You can also provide `BUILD_TYPE` for Static Linking of dependencies. This is optional and defaults to Shared.
+
+```
+cmake .. -DBUILD_TYPE=Static
+```
+
 On Windows, first, get `CMAKE_TOOLCHAIN_FILE` from the output of `"vcpkg integrate install"`, and then:
 ```
 cmake .. -G "Visual Studio 15 2017 Win64"

--- a/cmake_modules/Commons.cmake
+++ b/cmake_modules/Commons.cmake
@@ -26,16 +26,28 @@ endmacro()
 
 macro(add_dependent_packages_for_redex)
 
-    set(Boost_USE_STATIC_LIBS ON)
-    set(Boost_USE_STATIC_RUNTIME ON)
-    set(Boost_USE_MULTITHREADED ON)
+    message("-- ENABLE_STATIC ${ENABLE_STATIC}")
+
+    if(ENABLE_STATIC)
+        set(Boost_USE_STATIC_LIBS ON)
+        set(Boost_USE_STATIC_RUNTIME ON)
+        set(Boost_USE_MULTITHREADED ON)
+    endif()
+
     find_package(Boost 1.56.0 REQUIRED COMPONENTS system regex filesystem program_options iostreams thread)
     print_dirs("${Boost_INCLUDE_DIRS}" "Boost_INCLUDE_DIRS")
     print_dirs("${Boost_LIBRARIES}" "Boost_LIBRARIES")
 
     find_package(JsonCpp 0.10.5 REQUIRED)
     print_dirs("${JSONCPP_INCLUDE_DIRS}" "JSONCPP_INCLUDE_DIRS")
-    print_dirs("${JSONCPP_LIBRARY}" "JSONCPP_LIBRARY")
+
+    if(ENABLE_STATIC)
+        set(REDEX_JSONCPP_LIBRARY ${JSONCPP_LIBRARY_STATIC})
+    else()
+        set(REDEX_JSONCPP_LIBRARY ${JSONCPP_LIBRARY})
+    endif()
+
+    message("-- REDEX_JSONCPP_LIBRARY: ${REDEX_JSONCPP_LIBRARY}")
 
     if (NOT MSVC)
         set(JSONCPP_INCLUDE_DIRS "${JSONCPP_INCLUDE_DIRS}/jsoncpp")

--- a/cmake_modules/Commons.cmake
+++ b/cmake_modules/Commons.cmake
@@ -53,9 +53,25 @@ macro(add_dependent_packages_for_redex)
         set(JSONCPP_INCLUDE_DIRS "${JSONCPP_INCLUDE_DIRS}/jsoncpp")
     endif ()
 
+    if (APPLE)
+        #Static library is not installed on default path in MacOS because it conflicts with Xcode Version
+        set(ZLIB_HOME "/usr/local/opt/zlib/")
+    endif ()
+
     find_package(ZLIB REQUIRED)
+
+    print_dirs(${ZLIB_STATIC_LIB} "ZLIB_STATIC_LIB")
+    print_dirs(${ZLIB_SHARED_LIB} "ZLIB_SHARED_LIB")
+    
+    if (ENABLE_STATIC)
+        set(REDEX_ZLIB_LIBRARY ${ZLIB_STATIC_LIB})
+    else ()
+        set(REDEX_ZLIB_LIBRARY ${ZLIB_SHARED_LIB})
+    endif ()
+
     print_dirs("${ZLIB_INCLUDE_DIRS}" "ZLIB_INCLUDE_DIRS")
-    print_dirs("${ZLIB_LIBRARIES}" "ZLIB_LIBRARIES")
+    print_dirs("${REDEX_ZLIB_LIBRARY}" "REDEX_ZLIB_LIBRARY")
+
 endmacro()
 
 function(set_link_whole target_name lib_name)

--- a/cmake_modules/Commons.cmake
+++ b/cmake_modules/Commons.cmake
@@ -25,13 +25,13 @@ macro(set_common_cxx_flags_for_redex)
 endmacro()
 
 macro(add_dependent_packages_for_redex)
-    find_package(Boost 1.56.0 REQUIRED COMPONENTS system regex filesystem program_options iostreams thread)
-    print_dirs("${Boost_INCLUDE_DIRS}" "Boost_INCLUDE_DIRS")
-    print_dirs("${Boost_LIBRARIES}" "Boost_LIBRARIES")
 
     set(Boost_USE_STATIC_LIBS ON)
     set(Boost_USE_STATIC_RUNTIME ON)
     set(Boost_USE_MULTITHREADED ON)
+    find_package(Boost 1.56.0 REQUIRED COMPONENTS system regex filesystem program_options iostreams thread)
+    print_dirs("${Boost_INCLUDE_DIRS}" "Boost_INCLUDE_DIRS")
+    print_dirs("${Boost_LIBRARIES}" "Boost_LIBRARIES")
 
     find_package(JsonCpp 0.10.5 REQUIRED)
     print_dirs("${JSONCPP_INCLUDE_DIRS}" "JSONCPP_INCLUDE_DIRS")

--- a/cmake_modules/FindZlib.cmake
+++ b/cmake_modules/FindZlib.cmake
@@ -1,0 +1,104 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Tries to find ZLIB headers and libraries.
+#
+# Usage of this module as follows:
+#
+#  find_package(ZLIB)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  ZLIB_HOME - When set, this path is inspected instead of standard library
+#             locations as the root of the ZLIB installation.
+#             The environment variable ZLIB_HOME overrides this variable.
+#
+# - Find ZLIB (zlib.h, libz.a, libz.so, and libz.so.1)
+# This module defines
+#  ZLIB_INCLUDE_DIR, directory containing headers
+#  ZLIB_LIBS, directory containing zlib libraries
+#  ZLIB_STATIC_LIB, path to libz.a
+#  ZLIB_SHARED_LIB, path to libz's shared library
+#  ZLIB_FOUND, whether zlib has been found
+
+if( NOT "${ZLIB_HOME}" STREQUAL "")
+    file( TO_CMAKE_PATH "${ZLIB_HOME}" _native_path )
+    list( APPEND _zlib_roots ${_native_path} )
+elseif ( ZLIB_HOME )
+    list( APPEND _zlib_roots ${ZLIB_HOME} )
+endif()
+
+# Try the parameterized roots, if they exist
+if ( _zlib_roots )
+    find_path( ZLIB_INCLUDE_DIR NAMES zlib.h
+        PATHS ${_zlib_roots} NO_DEFAULT_PATH
+        PATH_SUFFIXES "include" )
+    find_library( ZLIB_LIBRARIES NAMES libz.a zlib
+        PATHS ${_zlib_roots} NO_DEFAULT_PATH
+        PATH_SUFFIXES "lib" )
+else ()
+    find_path( ZLIB_INCLUDE_DIR NAMES zlib.h )
+    # Only look for the static library
+    find_library( ZLIB_LIBRARIES NAMES libz.a zlib )
+endif ()
+
+if (ZLIB_INCLUDE_DIR AND (PARQUET_MINIMAL_DEPENDENCY OR ZLIB_LIBRARIES))
+  set(ZLIB_FOUND TRUE)
+  get_filename_component( ZLIB_LIBS ${ZLIB_LIBRARIES} PATH )
+  set(ZLIB_HEADER_NAME zlib.h)
+  set(ZLIB_HEADER ${ZLIB_INCLUDE_DIR}/${ZLIB_HEADER_NAME})
+  set(ZLIB_LIB_NAME z)
+  if (MSVC)
+    if (NOT ZLIB_MSVC_STATIC_LIB_SUFFIX)
+      set(ZLIB_MSVC_STATIC_LIB_SUFFIX libstatic)
+    endif()
+    set(ZLIB_MSVC_SHARED_LIB_SUFFIX lib)
+  endif()
+  set(ZLIB_STATIC_LIB ${ZLIB_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${ZLIB_LIB_NAME}${ZLIB_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
+  set(ZLIB_SHARED_LIB ${ZLIB_LIBS}/${CMAKE_SHARED_LIBRARY_PREFIX}${ZLIB_LIB_NAME}${ZLIB_MSVC_SHARED_LIB_SUFFIX}${CMAKE_SHARED_LIBRARY_SUFFIX})
+else ()
+  set(ZLIB_FOUND FALSE)
+endif ()
+
+if (ZLIB_FOUND)
+  if (NOT ZLIB_FIND_QUIETLY)
+    if (PARQUET_MINIMAL_DEPENDENCY)
+      message(STATUS "Found the ZLIB header: ${ZLIB_HEADER}")
+    else()
+      message(STATUS "Found the ZLIB library: ${ZLIB_LIBRARIES}")
+    endif ()
+  endif ()
+else ()
+  if (NOT ZLIB_FIND_QUIETLY)
+    set(ZLIB_ERR_MSG "Could not find the ZLIB library. Looked in ")
+    if ( _zlib_roots )
+      set(ZLIB_ERR_MSG "${ZLIB_ERR_MSG} in ${_zlib_roots}.")
+    else ()
+      set(ZLIB_ERR_MSG "${ZLIB_ERR_MSG} system search paths.")
+    endif ()
+    if (ZLIB_FIND_REQUIRED)
+      message(FATAL_ERROR "${ZLIB_ERR_MSG}")
+    else (ZLIB_FIND_REQUIRED)
+      message(STATUS "${ZLIB_ERR_MSG}")
+    endif (ZLIB_FIND_REQUIRED)
+  endif ()
+endif ()
+
+mark_as_advanced(
+  ZLIB_INCLUDE_DIR
+  ZLIB_LIBS
+  ZLIB_LIBRARIES
+  ZLIB_STATIC_LIB
+  ZLIB_SHARED_LIB
+)


### PR DESCRIPTION
Create an option to generate ReDex binaries with dependencies statically linked. 
Statically linked libraries will reduce the overhead of installing dependencies like Boost, JsonCpp & LibZ before using ReDex.

This PR adds a argument `BUILD_TYPE` that can be set to `Static` or `Shared` while configuring the build using CMake.

For e.g. 
`cmake .. -DBUILD_TYPE=Static && cmake --build .`

`BUILD_TYPE` defaults to `Shared`

Results: 

**Shared**
```
otool -L redex-all
redex-all:
	/usr/local/opt/boost/lib/libboost_system-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/local/opt/boost/lib/libboost_regex-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/local/opt/boost/lib/libboost_filesystem-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/local/opt/boost/lib/libboost_program_options-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/local/opt/boost/lib/libboost_iostreams-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/local/opt/boost/lib/libboost_thread-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/local/opt/boost/lib/libboost_chrono-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/local/opt/boost/lib/libboost_date_time-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/local/opt/boost/lib/libboost_atomic-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/local/opt/jsoncpp/lib/libjsoncpp.19.dylib (compatibility version 19.0.0, current version 1.8.4)
	/usr/local/opt/zlib/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 400.9.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.50.4)
```

**Static**
```
$ otool -L redex-all
redex-all:
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 400.9.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.50.4)
```

Depends On: #345 