### PR TITLE
Fix syntax warning in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ file(GLOB includes
         "liblocator"
         "libresource"
         "shared"
-        "sparta/include",
+        "sparta/include"
         "tools/common"
         )
 
@@ -76,8 +76,8 @@ add_library(resource STATIC ${resource_srcs})
 
 file(GLOB redex_all_srcs
         "tools/redex-all/*.cpp"
-        "tools/redex-all/*.h",
-        "tools/common/*.cpp",
+        "tools/redex-all/*.h"
+        "tools/common/*.cpp"
         "tools/common/*.h"
         )
 


### PR DESCRIPTION
Fix the warnings `Argument not separated from preceding token by whitespace.`
The issue was caused in https://github.com/facebook/redex/pull/345 authored by me. This fixes the same. 

The following warnings are fixed:

```
CMake Warning (dev) at CMakeLists.txt:32:
  Syntax Warning in cmake code at column 25

  Argument not separated from preceding token by whitespace.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at CMakeLists.txt:79:
  Syntax Warning in cmake code at column 30

  Argument not separated from preceding token by whitespace.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at CMakeLists.txt:80:
  Syntax Warning in cmake code at column 29

  Argument not separated from preceding token by whitespace.
This warning is for project developers.  Use -Wno-dev to suppress it.
```