### PR TITLE
add config option to impose instruction size limit

### DIFF
--- a/libredex/ConfigFiles.cpp
+++ b/libredex/ConfigFiles.cpp
@@ -163,6 +163,13 @@ ConfigFiles::ConfigFiles(const Json::Value& config, const std::string& outdir)
     load_method_to_weight();
   }
   load_method_sorting_whitelisted_substrings();
+  uint32_t instruction_size_bitwidth_limit =
+      config.get("instruction_size_bitwidth_limit", 0).asUInt();
+  always_assert_log(
+      instruction_size_bitwidth_limit < 32,
+      "instruction_size_bitwidth_limit must be between 0 and 31, actual: %u\n",
+      instruction_size_bitwidth_limit);
+  m_instruction_size_bitwidth_limit = instruction_size_bitwidth_limit;
 }
 
 ConfigFiles::ConfigFiles(const Json::Value& config) : ConfigFiles(config, "") {}

--- a/libredex/ConfigFiles.h
+++ b/libredex/ConfigFiles.h
@@ -144,6 +144,10 @@ struct ConfigFiles {
 
   const std::string& get_printseeds() const { return m_printseeds; }
 
+  uint32_t get_instruction_size_bitwidth_limit() const {
+    return m_instruction_size_bitwidth_limit;
+  }
+
   const JsonWrapper& get_json_config() const { return m_json; }
 
  private:
@@ -169,6 +173,10 @@ struct ConfigFiles {
   std::unordered_map<std::string, unsigned int> m_method_to_weight;
   std::unordered_set<std::string> m_method_sorting_whitelisted_substrings;
   std::string m_printseeds; // Filename to dump computed seeds.
+
+  // limits the output instruction size of any DexMethod to 2^n
+  // 0 when limit is not present
+  uint32_t m_instruction_size_bitwidth_limit;
 
   // global no optimizations annotations
   std::unordered_set<DexType*> m_no_optimizations_annos;

--- a/libredex/DexOutput.h
+++ b/libredex/DexOutput.h
@@ -313,4 +313,7 @@ class DexOutput {
                const std::vector<SortMode>& code_mode,
                const ConfigFiles& cfg);
   void write();
+  static void check_method_instruction_size_limit(const ConfigFiles& cfg,
+                                                  int size,
+                                                  const char* method_name);
 };

--- a/test/unit/DexOutputTest.cpp
+++ b/test/unit/DexOutputTest.cpp
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "DexOutput.h"
+#include <gtest/gtest.h>
+#include <json/json.h>
+
+TEST(DexOutput, checkMethodInstructionSizeLimit) {
+
+  Json::Value json_cfg;
+  std::istringstream temp_json(
+      "{\"redex\":{\"passes\":[]}, \"instruction_size_bitwidth_limit\": 0}");
+
+  temp_json >> json_cfg;
+  json_cfg["instruction_size_bitwidth_limit"] = 16;
+  ConfigFiles cfg(json_cfg);
+  EXPECT_NO_THROW(
+      DexOutput::check_method_instruction_size_limit(cfg, 65536, "method"));
+  EXPECT_THROW(
+      DexOutput::check_method_instruction_size_limit(cfg, 65537, "method"),
+      std::runtime_error);
+}


### PR DESCRIPTION
Summary: Added check for method size in DexOutput

Reviewed By: thezhangwei

Differential Revision: D14329266
