### PR TITLE
extend constant propagation to more instructions

### DIFF
--- a/libredex/DexInstruction.h
+++ b/libredex/DexInstruction.h
@@ -415,3 +415,11 @@ inline bool is_monitor(IROpcode op) {
 }
 
 inline bool is_instance_of(IROpcode op) { return op == OPCODE_INSTANCE_OF; }
+
+inline bool is_div_int_lit(IROpcode op) {
+  return op == OPCODE_DIV_INT_LIT16 || op == OPCODE_DIV_INT_LIT8;
+}
+
+inline bool is_rem_int_lit(IROpcode op) {
+  return op == OPCODE_REM_INT_LIT16 || op == OPCODE_REM_INT_LIT8;
+}

--- a/opt/constant-propagation/ConstantPropagationTransform.cpp
+++ b/opt/constant-propagation/ConstantPropagationTransform.cpp
@@ -94,7 +94,8 @@ void Transform::simplify_instruction(const ConstantEnvironment& env,
   case IOPCODE_MOVE_RESULT_PSEUDO_OBJECT: {
     auto* primary_insn = ir_list::primary_instruction_of_move_result_pseudo(it);
     auto op = primary_insn->opcode();
-    if (is_sget(op) || is_aget(op)) {
+    if (is_sget(op) || is_aget(op) || is_div_int_lit(op) ||
+        is_rem_int_lit(op)) {
       replace_with_const(env, it);
     }
     break;
@@ -115,7 +116,18 @@ void Transform::simplify_instruction(const ConstantEnvironment& env,
   case OPCODE_ADD_INT_LIT16:
   case OPCODE_ADD_INT_LIT8:
   case OPCODE_RSUB_INT:
-  case OPCODE_RSUB_INT_LIT8: {
+  case OPCODE_RSUB_INT_LIT8:
+  case OPCODE_MUL_INT_LIT16:
+  case OPCODE_MUL_INT_LIT8:
+  case OPCODE_AND_INT_LIT16:
+  case OPCODE_AND_INT_LIT8:
+  case OPCODE_OR_INT_LIT16:
+  case OPCODE_OR_INT_LIT8:
+  case OPCODE_XOR_INT_LIT16:
+  case OPCODE_XOR_INT_LIT8:
+  case OPCODE_SHL_INT_LIT8:
+  case OPCODE_SHR_INT_LIT8:
+  case OPCODE_USHR_INT_LIT8: {
     replace_with_const(env, it);
     break;
   }

--- a/service/constant-propagation/ConstantPropagationAnalysis.cpp
+++ b/service/constant-propagation/ConstantPropagationAnalysis.cpp
@@ -68,6 +68,16 @@ bool subtraction_out_of_bounds(int64_t a, int64_t b) {
   return false;
 }
 
+bool multiply_out_of_bounds(int64_t a, int64_t b) {
+  int32_t max = std::numeric_limits<int32_t>::max();
+  int32_t min = std::numeric_limits<int32_t>::min();
+  if (a && b && ((a * b / b != a) || (a * b / a != b))) {
+    TRACE(CONSTP, 5, "%d * %d is out of bounds", a, b);
+    return true;
+  }
+  return false;
+}
+
 // Propagate the result of a compare if the operands are known constants.
 // If we know enough, put -1, 0, or 1 into the destination register.
 //
@@ -268,43 +278,89 @@ bool PrimitiveAnalyzer::analyze_cmp(const IRInstruction* insn,
 bool PrimitiveAnalyzer::analyze_binop_lit(const IRInstruction* insn,
                                           ConstantEnvironment* env) {
   auto op = insn->opcode();
-  const static std::set<IROpcode> accepted_opcodes = {
-      OPCODE_ADD_INT_LIT16, OPCODE_ADD_INT_LIT8, // addition
-      OPCODE_RSUB_INT, OPCODE_RSUB_INT_LIT8, // reverse subtraction
-      // TODO: add more instructions
-  };
-  if (accepted_opcodes.find(op) != accepted_opcodes.end()) {
-    int32_t lit = insn->get_literal();
-    TRACE(CONSTP, 5, "Attempting to fold %s with literal %lu\n", SHOW(insn),
-          lit);
+  int32_t lit = insn->get_literal();
+  TRACE(CONSTP, 5, "Attempting to fold %s with literal %lu\n", SHOW(insn), lit);
 
-    auto result = SignedConstantDomain::top();
-    auto cst = env->get<SignedConstantDomain>(insn->src(0)).get_constant();
+  auto result = SignedConstantDomain::top();
+  auto cst = env->get<SignedConstantDomain>(insn->src(0)).get_constant();
 
-    if (cst) {
-      switch (op) {
-      case OPCODE_ADD_INT_LIT16:
-      case OPCODE_ADD_INT_LIT8:
-        // add-int/lit8 is the most common arithmetic instruction: about .29% of
-        // all instructions. All other arithmetic instructions are less than
-        // .05%
-        if (!addition_out_of_bounds(*cst, lit)) {
-          result = SignedConstantDomain(*cst + lit);
-        }
-        break;
-      // TODO: add more
-      case OPCODE_RSUB_INT:
-      case OPCODE_RSUB_INT_LIT8:
-        if (!subtraction_out_of_bounds(lit, *cst)) {
-          result = SignedConstantDomain(lit - *cst);
-        }
-        break;
-      default:
-        break;
+  if (cst) {
+    bool use_result_reg = false;
+    switch (op) {
+    case OPCODE_ADD_INT_LIT16:
+    case OPCODE_ADD_INT_LIT8: {
+      // add-int/lit8 is the most common arithmetic instruction: about .29% of
+      // all instructions. All other arithmetic instructions are less than
+      // .05%
+      if (!addition_out_of_bounds(*cst, lit)) {
+        result = SignedConstantDomain(*cst + lit);
       }
+      break;
     }
-
-    env->set(insn->dest(), result);
+    case OPCODE_RSUB_INT:
+    case OPCODE_RSUB_INT_LIT8: {
+      if (!subtraction_out_of_bounds(lit, *cst)) {
+        result = SignedConstantDomain(lit - *cst);
+      }
+      break;
+    }
+    case OPCODE_MUL_INT_LIT16:
+    case OPCODE_MUL_INT_LIT8: {
+      if (!multiply_out_of_bounds(*cst, lit)) {
+        result = SignedConstantDomain(*cst * lit);
+      }
+      break;
+    }
+    case OPCODE_DIV_INT_LIT16:
+    case OPCODE_DIV_INT_LIT8: {
+      if (lit != 0) {
+        result = SignedConstantDomain(*cst / lit);
+      }
+      use_result_reg = true;
+      break;
+    }
+    case OPCODE_REM_INT_LIT16:
+    case OPCODE_REM_INT_LIT8: {
+      if (lit != 0) {
+        result = SignedConstantDomain(*cst % lit);
+      }
+      use_result_reg = true;
+      break;
+    }
+    case OPCODE_AND_INT_LIT16:
+    case OPCODE_AND_INT_LIT8: {
+      result = SignedConstantDomain(*cst & lit);
+      break;
+    }
+    case OPCODE_OR_INT_LIT16:
+    case OPCODE_OR_INT_LIT8: {
+      result = SignedConstantDomain(*cst | lit);
+      break;
+    }
+    case OPCODE_XOR_INT_LIT16:
+    case OPCODE_XOR_INT_LIT8: {
+      result = SignedConstantDomain(*cst ^ lit);
+      break;
+    }
+    // as in https://source.android.com/devices/tech/dalvik/dalvik-bytecode
+    // the following operations have the second operand masked.
+    case OPCODE_SHL_INT_LIT8: {
+      result = SignedConstantDomain(*cst << (lit & 0x1f));
+      break;
+    }
+    case OPCODE_SHR_INT_LIT8: {
+      result = SignedConstantDomain(*cst >> (lit & 0x1f));
+      break;
+    }
+    case OPCODE_USHR_INT_LIT8: {
+      uint32_t ucst = *cst;
+      result = SignedConstantDomain(ucst >> (lit & 0x1f));
+      break;
+    }
+    default:
+      break;
+    }
+    env->set(use_result_reg ? RESULT_REGISTER : insn->dest(), result);
     return true;
   }
   return analyze_default(insn, env);

--- a/test/instr/ConstantPropagationTest.cpp
+++ b/test/instr/ConstantPropagationTest.cpp
@@ -59,6 +59,26 @@ TEST_F(PreVerify, ConstantPropagation) {
     if (meth->get_name()->str().find("lit_minus") != std::string::npos) {
       EXPECT_EQ(1, count_ops(code->cfg(), OPCODE_RSUB_INT_LIT8));
     }
+    if (meth->get_name()->str().find("multiply_lit_const") !=
+        std::string::npos) {
+      EXPECT_EQ(1, count_ops(code->cfg(), OPCODE_MUL_INT_LIT8));
+    }
+    if (meth->get_name()->str().find("multiply_large_lit_const") !=
+        std::string::npos) {
+      EXPECT_EQ(1, count_ops(code->cfg(), OPCODE_MUL_INT_LIT16));
+    }
+    if (meth->get_name()->str().find("shl_lit_const") != std::string::npos) {
+      EXPECT_EQ(1, count_ops(code->cfg(), OPCODE_SHL_INT_LIT8));
+    }
+    if (meth->get_name()->str().find("if_shr_lit_const") != std::string::npos) {
+      EXPECT_EQ(1, count_ops(code->cfg(), OPCODE_SHR_INT_LIT8));
+    }
+    if (meth->get_name()->str().find("ushr_lit_const") != std::string::npos) {
+      EXPECT_EQ(1, count_ops(code->cfg(), OPCODE_USHR_INT_LIT8));
+    }
+    if (meth->get_name()->str().find("modulo_3") != std::string::npos) {
+      EXPECT_EQ(1, count_ops(code->cfg(), OPCODE_REM_INT_LIT8));
+    }
     code->clear_cfg();
   }
 }
@@ -80,17 +100,35 @@ TEST_F(PostVerify, ConstantPropagation) {
     }
 
     EXPECT_EQ(0, count_ifs(code->cfg()));
-    if (meth->get_name()->str().find("plus_one") != std::string::npos) {
-      EXPECT_EQ(0, count_ops(code->cfg(), OPCODE_ADD_INT_LIT8));
-    }
-
-    if (meth->get_name()->str().find("lit_minus") != std::string::npos) {
-      EXPECT_EQ(0, count_ops(code->cfg(), OPCODE_RSUB_INT_LIT8));
-    }
-
     if (meth->get_name()->str().find("overflow") != std::string::npos) {
       // make sure we don't fold overflow at compile time
       EXPECT_EQ(1, count_ops(code->cfg(), OPCODE_ADD_INT_LIT8));
+    }
+    if (meth->get_name()->str().find("plus_one") != std::string::npos) {
+      EXPECT_EQ(0, count_ops(code->cfg(), OPCODE_ADD_INT_LIT8));
+    }
+    if (meth->get_name()->str().find("lit_minus") != std::string::npos) {
+      EXPECT_EQ(0, count_ops(code->cfg(), OPCODE_RSUB_INT_LIT8));
+    }
+    if (meth->get_name()->str().find("multiply_lit_const") !=
+        std::string::npos) {
+      EXPECT_EQ(0, count_ops(code->cfg(), OPCODE_MUL_INT_LIT8));
+    }
+    if (meth->get_name()->str().find("multiply_large_lit_const") !=
+        std::string::npos) {
+      EXPECT_EQ(0, count_ops(code->cfg(), OPCODE_MUL_INT_LIT16));
+    }
+    if (meth->get_name()->str().find("shl_lit_const") != std::string::npos) {
+      EXPECT_EQ(0, count_ops(code->cfg(), OPCODE_SHL_INT_LIT8));
+    }
+    if (meth->get_name()->str().find("if_shr_lit_const") != std::string::npos) {
+      EXPECT_EQ(0, count_ops(code->cfg(), OPCODE_SHR_INT_LIT8));
+    }
+    if (meth->get_name()->str().find("ushr_lit_const") != std::string::npos) {
+      EXPECT_EQ(0, count_ops(code->cfg(), OPCODE_USHR_INT_LIT8));
+    }
+    if (meth->get_name()->str().find("modulo_3") != std::string::npos) {
+      EXPECT_EQ(0, count_ops(code->cfg(), OPCODE_REM_INT_LIT8));
     }
     code->clear_cfg();
   }

--- a/test/instr/ConstantPropagationTest.java
+++ b/test/instr/ConstantPropagationTest.java
@@ -132,6 +132,14 @@ public class ConstantPropagationTest {
     return 1;
   }
 
+  private int two() {
+    return 2;
+  }
+
+  private int sixteen() {
+    return 16;
+  }
+
   // This test intentionally does not use the same constant literal more than
   // once. The reason is that d8 will load that constant and re-use the
   // register rather than using a add-int/lit instruction. Currently
@@ -158,7 +166,7 @@ public class ConstantPropagationTest {
   }
 
   @Test
-  public void lit_minus() {
+  public void if_lit_minus() {
     int x = one();
     int y = 5 - x;
     int z;
@@ -168,5 +176,83 @@ public class ConstantPropagationTest {
       z = 0;
     }
     assertThat(z).isEqualTo(42);
+  }
+
+  @Test
+  public void if_multiply_lit_const() {
+    int x = two();
+    int y = 42 * x;
+    int z;
+    if (y == 84) {
+      z = 1;
+    } else {
+      z = 0;
+    }
+    assertThat(z).isEqualTo(1);
+  }
+
+  @Test
+  public void if_multiply_large_lit_const() {
+    int x = two();
+    int y = 32767 * x;
+    int z;
+    if (y == 65534) {
+      z = 1;
+    } else {
+      z = 0;
+    }
+    assertThat(z).isEqualTo(1);
+  }
+
+  @Test
+  public void if_shl_lit_const() {
+    int x = two();
+    int y = x << 2;
+    int z;
+    if (y == 8) {
+      z = 1;
+    } else {
+      z = 0;
+    }
+    assertThat(z).isEqualTo(1);
+  }
+
+  @Test
+  public void if_shr_lit_const() {
+    int x = sixteen();
+    int y = x >> 2;
+    int z;
+    if (y == 4) {
+      z = 1;
+    } else {
+      z = 0;
+    }
+    assertThat(z).isEqualTo(1);
+  }
+
+  @Test
+  public void if_ushr_lit_const() {
+    int x = neg1() * 16;
+    int y = x >>> 5;
+    int z;
+    if (y == 134217727) {
+      z = 1;
+    } else {
+      z = 0;
+    }
+    assertThat(z).isEqualTo(1);
+  }
+
+  @Test
+  public void if_modulo_3() {
+    int x = sixteen();
+    int y = x % 3;
+    int z;
+    if (y == 1) {
+      z = 1;
+    } else {
+      z = 0;
+    }
+    assertThat(z).isEqualTo(1);
   }
 }

--- a/test/unit/constant-propagation/SignedConstantPropagationTest.cpp
+++ b/test/unit/constant-propagation/SignedConstantPropagationTest.cpp
@@ -444,3 +444,143 @@ TEST(ConstantPropagation, ConditionalConstantInferInterval) {
   EXPECT_EQ(assembler::to_s_expr(code.get()),
             assembler::to_s_expr(expected_code.get()));
 }
+
+TEST(ConstantPropagation, FoldBitwiseAndLit) {
+  auto code = assembler::ircode_from_string(R"(
+    (
+      (const v0 1023)
+      (and-int/lit16 v0 v0 511)
+      (and-int/lit8 v0 v0 255)
+      (return-void)
+    )
+  )");
+  do_const_prop(code.get());
+  auto expected_code = assembler::ircode_from_string(R"(
+    (
+      (const v0 1023)
+      (const v0 511)
+      (const v0 255)
+      (return-void)
+    )
+  )");
+  EXPECT_EQ(assembler::to_s_expr(code.get()),
+            assembler::to_s_expr(expected_code.get()));
+}
+
+TEST(ConstantPropagation, FoldBitwiseOrLit) {
+  auto code = assembler::ircode_from_string(R"(
+    (
+      (const v0 257)
+      (or-int/lit8 v0 v0 255)
+      (or-int/lit16 v0 v0 1024)
+      (return-void)
+    )
+  )");
+  do_const_prop(code.get());
+  auto expected_code = assembler::ircode_from_string(R"(
+    (
+      (const v0 257)
+      (const v0 511)
+      (const v0 1535)
+      (return-void)
+    )
+  )");
+  EXPECT_EQ(assembler::to_s_expr(code.get()),
+            assembler::to_s_expr(expected_code.get()));
+}
+
+TEST(ConstantPropagation, FoldBitwiseXorLit) {
+  auto code = assembler::ircode_from_string(R"(
+    (
+      (const v0 1023)
+      (xor-int/lit16 v0 v0 512)
+      (xor-int/lit8 v0 v0 255)
+      (return-void)
+    )
+  )");
+  do_const_prop(code.get());
+  auto expected_code = assembler::ircode_from_string(R"(
+    (
+      (const v0 1023)
+      (const v0 511)
+      (const v0 256)
+      (return-void)
+    )
+  )");
+  EXPECT_EQ(assembler::to_s_expr(code.get()),
+            assembler::to_s_expr(expected_code.get()));
+}
+
+TEST(ConstantPropagation, FoldBitwiseShiftLit) {
+  auto code = assembler::ircode_from_string(R"(
+    (
+      (const v0 1023)
+      (shr-int/lit8 v0 v0 2)
+      (shl-int/lit8 v0 v0 1)
+      (return-void)
+    )
+  )");
+  do_const_prop(code.get());
+  auto expected_code = assembler::ircode_from_string(R"(
+    (
+      (const v0 1023)
+      (const v0 255)
+      (const v0 510)
+      (return-void)
+    )
+  )");
+  EXPECT_EQ(assembler::to_s_expr(code.get()),
+            assembler::to_s_expr(expected_code.get()));
+}
+
+TEST(ConstantPropagation, FoldBitwiseArithAndLogicalRightShiftLit) {
+  auto code = assembler::ircode_from_string(R"(
+    (
+      (const v0 -1024)
+      (shr-int/lit8 v0 v0 2)
+      (ushr-int/lit8 v0 v0 12)
+      (return-void)
+    )
+  )");
+  do_const_prop(code.get());
+  auto expected_code = assembler::ircode_from_string(R"(
+    (
+      (const v0 -1024)
+      (const v0 -256)
+      (const v0 1048575)
+      (return-void)
+    )
+  )");
+  EXPECT_EQ(assembler::to_s_expr(code.get()),
+            assembler::to_s_expr(expected_code.get()));
+}
+
+TEST(ConstantPropagation, FoldDivIntLit) {
+  auto code = assembler::ircode_from_string(R"(
+    (
+      (const v0 4096)
+      (div-int/lit16 v0 512)
+      (move-result-pseudo v1)
+      (const v0 15)
+      (div-int/lit8 v0 2)
+      (move-result-pseudo v1)
+      (div-int/lit8 v0 0)
+      (move-result-pseudo v2)
+      (return-void)
+    )
+  )");
+  do_const_prop(code.get());
+  auto expected_code = assembler::ircode_from_string(R"(
+    (
+      (const v0 4096)
+      (const v1 8)
+      (const v0 15)
+      (const v1 7)
+      (div-int/lit8 v0 0)
+      (move-result-pseudo v2)
+      (return-void)
+    )
+  )"); // division by 0 should not be optimized out
+  EXPECT_EQ(assembler::to_s_expr(code.get()),
+            assembler::to_s_expr(expected_code.get()));
+}


### PR DESCRIPTION
Summary: Implement and test constant propagation for arithmetic operations involving literals

Differential Revision: D14372191
