### PR TITLE
Support for the simplest version of Android Bundles

### DIFF
--- a/redex.py
+++ b/redex.py
@@ -579,7 +579,15 @@ def ensure_libs_dir(libs_dir, sub_dir):
         os.mkdir(libs_dir)
         os.mkdir(sub_dir)
         return libs_dir
-
+    
+def get_dex_file_path(args, extracted_apk_dir):
+    # base on file extension check if input is
+    # an apk file (".apk") or an Android bundle file (".aab")
+    log("APK: "+os.path.splitext(args.input_apk)[1])
+    if os.path.splitext(args.input_apk)[1] == ".aab":
+        return join(extracted_apk_dir, "base", "dex")
+    else:
+        return extracted_apk_dir
 
 def prepare_redex(args):
     debug_mode = args.unpack_only or args.debug
@@ -644,10 +652,8 @@ def prepare_redex(args):
     log('Extracting apk...')
     unzip_apk(args.input_apk, extracted_apk_dir)
 
-    dex_file_path = extracted_apk_dir
-    if os.path.splitext(args.out)[1] == "aab":
-        dex_file_path = join(extracted_apk_dir,"base","dex")
-
+    dex_file_path = get_dex_file_path(args, extracted_apk_dir)
+    
     dex_mode = unpacker.detect_secondary_dex_mode(dex_file_path)
     log('Detected dex mode ' + str(type(dex_mode).__name__))
     if not dex_dir:
@@ -775,12 +781,8 @@ def finalize_redex(state):
     log("Emit Locator Strings: %s" % have_locators)
     log("Emit Name Based Locator Strings: %s" % have_name_based_locators)
 
-    dex_file_path = extracted_apk_dir
-    if os.path.splitext(state.args.out)[1] == "aab":
-        dex_file_path = join(extracted_apk_dir,"base","dex")
-
     state.dex_mode.repackage(
-        dex_file_path, state.dex_dir, have_locators, have_name_based_locators, fast_repackage=state.args.dev
+        get_dex_file_path(state.args, state.extracted_apk_dir), state.dex_dir, have_locators, have_name_based_locators, fast_repackage=state.args.dev
     )
 
     locator_store_id = 1

--- a/redex.py
+++ b/redex.py
@@ -580,20 +580,23 @@ def ensure_libs_dir(libs_dir, sub_dir):
         os.mkdir(sub_dir)
         return libs_dir
 
+
 def get_file_ext(file_name):
     return os.path.splitext(file_name)[1]
-    
+
+
 def get_dex_file_path(args, extracted_apk_dir):
     # base on file extension check if input is
     # an apk file (".apk") or an Android bundle file (".aab")
     # TODO: support loadable modules (at this point only
-    # very basic support is provided - in case of Android bundles 
+    # very basic support is provided - in case of Android bundles
     # "regular" apk file content is moved to the "base"
     # sub-directory of the bundle archive)
     if get_file_ext(args.input_apk) == ".aab":
         return join(extracted_apk_dir, "base", "dex")
     else:
         return extracted_apk_dir
+
 
 def prepare_redex(args):
     debug_mode = args.unpack_only or args.debug
@@ -606,7 +609,7 @@ def prepare_redex(args):
             get_file_ext(args.input_apk) +\
             "\") should be the same as output file extension (\"" +\
             get_file_ext(args.out) + "\")"
-    
+
     extracted_apk_dir = None
     dex_dir = None
     if args.unpack_only and args.unpack_dest:
@@ -668,7 +671,7 @@ def prepare_redex(args):
     unzip_apk(args.input_apk, extracted_apk_dir)
 
     dex_file_path = get_dex_file_path(args, extracted_apk_dir)
-    
+
     dex_mode = unpacker.detect_secondary_dex_mode(dex_file_path)
     log('Detected dex mode ' + str(type(dex_mode).__name__))
     if not dex_dir:

--- a/redex.py
+++ b/redex.py
@@ -644,13 +644,17 @@ def prepare_redex(args):
     log('Extracting apk...')
     unzip_apk(args.input_apk, extracted_apk_dir)
 
-    dex_mode = unpacker.detect_secondary_dex_mode(extracted_apk_dir)
+    dex_file_path = extracted_apk_dir
+    if os.path.splitext(args.out)[1] == "aab":
+        dex_file_path = join(extracted_apk_dir,"base","dex")
+
+    dex_mode = unpacker.detect_secondary_dex_mode(dex_file_path)
     log('Detected dex mode ' + str(type(dex_mode).__name__))
     if not dex_dir:
         dex_dir = make_temp_dir('.redex_dexen', debug_mode)
 
     log('Unpacking dex files')
-    dex_mode.unpackage(extracted_apk_dir, dex_dir)
+    dex_mode.unpackage(dex_file_path, dex_dir)
 
     log('Detecting Application Modules')
     application_modules = unpacker.ApplicationModule.detect(extracted_apk_dir)
@@ -771,8 +775,12 @@ def finalize_redex(state):
     log("Emit Locator Strings: %s" % have_locators)
     log("Emit Name Based Locator Strings: %s" % have_name_based_locators)
 
+    dex_file_path = extracted_apk_dir
+    if os.path.splitext(state.args.out)[1] == "aab":
+        dex_file_path = join(extracted_apk_dir,"base","dex")
+
     state.dex_mode.repackage(
-        state.extracted_apk_dir, state.dex_dir, have_locators, have_name_based_locators, fast_repackage=state.args.dev
+        dex_file_path, state.dex_dir, have_locators, have_name_based_locators, fast_repackage=state.args.dev
     )
 
     locator_store_id = 1

--- a/redex.py
+++ b/redex.py
@@ -579,12 +579,18 @@ def ensure_libs_dir(libs_dir, sub_dir):
         os.mkdir(libs_dir)
         os.mkdir(sub_dir)
         return libs_dir
+
+def get_file_ext(file_name):
+    return os.path.splitext(file_name)[1]
     
 def get_dex_file_path(args, extracted_apk_dir):
     # base on file extension check if input is
     # an apk file (".apk") or an Android bundle file (".aab")
-    log("APK: "+os.path.splitext(args.input_apk)[1])
-    if os.path.splitext(args.input_apk)[1] == ".aab":
+    # TODO: support loadable modules (at this point only
+    # very basic support is provided - in case of Android bundles 
+    # "regular" apk file content is moved to the "base"
+    # sub-directory of the bundle archive)
+    if get_file_ext(args.input_apk) == ".aab":
         return join(extracted_apk_dir, "base", "dex")
     else:
         return extracted_apk_dir
@@ -592,6 +598,15 @@ def get_dex_file_path(args, extracted_apk_dir):
 def prepare_redex(args):
     debug_mode = args.unpack_only or args.debug
 
+    # avoid accidentally mixing up file formats since we now support
+    # both apk files and Android bundle files
+    if not args.unpack_only:
+        assert get_file_ext(args.input_apk) == get_file_ext(args.out),\
+            "Input file extension (\"" +\
+            get_file_ext(args.input_apk) +\
+            "\") should be the same as output file extension (\"" +\
+            get_file_ext(args.out) + "\")"
+    
     extracted_apk_dir = None
     dex_dir = None
     if args.unpack_only and args.unpack_dest:


### PR DESCRIPTION
As per https://github.com/facebook/redex/issues/367, we will need support for Android Bundles pretty soon and I was hoping we can get at least some rudimentary support into ReDex sooner rather than later. 

The submitted patch works for us, but I am not sure if it's generic enough for the general audience. The missing bits was to tell the unpacker where the dex files are located in the archive, which is needed to (1) determine secondary dex mode, (2) unpackage dex files to a separate directory and (3) copy ReDex-processed dex files back to the directory containing unzipped archive.

I would be very happy to work on this further given some feedback on how to finesse/generalize it if need be.

I also made a decision of distinguishing the "mode" (APK or bundle) based on file extension - other options are clearly a possibility as well, though.