### PR TITLE
Remove need of proguard config for DCE pass

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,15 +8,21 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif ()
 
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+
 if(NOT BUILD_TYPE)
     set(BUILD_TYPE Shared)
 endif ()
+
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
 if(BUILD_TYPE STREQUAL Static)
     set(ENABLE_STATIC ON CACHE BOOL "" FORCE)
 elseif (BUILD_TYPE STREQUAL Shared)
     set(ENABLE_STATIC OFF CACHE BOOL "" FORCE)
 endif ()
+
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
 set_common_cxx_flags_for_redex()
 add_dependent_packages_for_redex()

--- a/opt/local-dce/LocalDce.cpp
+++ b/opt/local-dce/LocalDce.cpp
@@ -321,12 +321,6 @@ bool LocalDce::assumenosideeffects(DexMethodRef* ref, DexMethod* meth) {
 void LocalDcePass::run_pass(DexStoresVector& stores,
                             ConfigFiles& conf,
                             PassManager& mgr) {
-  if (mgr.no_proguard_rules()) {
-    TRACE(DCE, 1,
-          "LocalDcePass not run because no ProGuard configuration was "
-          "provided.");
-    return;
-  }
   auto scope = build_class_scope(stores);
   auto pure_methods = find_pure_methods(scope);
   auto configured_pure_methods = conf.get_pure_methods();


### PR DESCRIPTION
1. Add -pthread to compile without errors for cmake.
2. Remove proguard config check from LocalDCEPass. Thanks @justinjhendrick.