### PR TITLE
Fix destination register types for ifield_op & sfield_op

### DIFF
--- a/libredex/Creators.cpp
+++ b/libredex/Creators.cpp
@@ -164,7 +164,7 @@ void MethodBlock::ifield_op(IROpcode opcode,
   if (is_iget(opcode)) {
     auto iget = new IRInstruction(opcode);
     iget->set_field(field);
-    src_or_dst.type = field->get_class();
+    src_or_dst.type = field->get_type();
     iget->set_src(0, obj.get_reg());
     push_instruction(iget);
     push_instruction(
@@ -256,7 +256,7 @@ void MethodBlock::sfield_op(IROpcode opcode,
   if (is_sget(opcode)) {
     auto sget = new IRInstruction(opcode);
     sget->set_field(field);
-    src_or_dst.type = field->get_class();
+    src_or_dst.type = field->get_type();
     push_instruction(sget);
     push_instruction(
         (new IRInstruction(opcode::move_result_pseudo_for_sget(opcode)))


### PR DESCRIPTION
This fixes the destination register types for ifield_op & sfield_op.
Previously, they were setting the destination register type to the target field's container instead of the target field's type.

Edit: Signed the CLA & also this is the regression test I'm using:

```
  /* Create a reference to `bar` in `class Foo { public static int bar; }` */
  DexType* Foo_type = DexType::make_type("LFoo;");
  DexField* static_int_field = DexField::make_field(Foo_type, DexString::make_string("bar"), type::_int())
      ->make_concrete(ACC_PUBLIC | ACC_STATIC);

  /* Create `static int baz() { return Foo.bar; } */
  MethodCreator mc(Foo_type, DexString::make_string("baz"), DexProto::make_proto(type::_int(), DexTypeList::make_type_list({})), ACC_STATIC);
  auto v0 = mc.make_local(type::_int());
  mc.get_main_block()->sget(static_int_field, v0);
  mc.get_main_block()->ret(v0);
  auto* method = mc.create();

  // The return opcode used to be RETURN_OBJECT
  //   since we were setting v0's type to `LFoo;` instead of `I`
  auto expected = assembler::ircode_from_string(R"((
    (sget "LFoo;.bar:I")
    (move-result-pseudo v0)
    (return v0)
  ))");
  EXPECT_CODE_EQ(method->get_code(), expected.get());
```