### PR TITLE
 [dex.py] Fix parsing Proguard rename maps whose class mappings end in :

### DIFF
--- a/tools/python/dex.py
+++ b/tools/python/dex.py
@@ -1171,6 +1171,7 @@ class Progard:
                             class_dict[new] = old
                     else:
                         (old, new) = line.split(" -> ")
+                        new = new.rstrip(":")
                         # print('class old = "%s"' % (old))
                         # print('class new = "%s"' % (new))
                         class_dict = {}


### PR DESCRIPTION
It looks like some proguard rename mapping files are of the form:
```
OldClsName -> ShortClsName:
   ...
```

This change fixes parsing these files. When the files don't have the trailing `:` this change is a no-op so it should be safe for any previous use cases.