### PR TITLE
[dex.py] Add len() to parsed dex structures

### DIFF
--- a/tools/python/dex.py
+++ b/tools/python/dex.py
@@ -1207,6 +1207,12 @@ class DexMethod:
         self.name_in_file = None
         self.name = None
 
+    def __len__(self):
+        ci = self.get_code_item()
+        return (len(self.encoded_method) if self.encoded_method else 0) + (
+            len(ci) if ci else 0
+        )
+
     def get_signature(self):
         class_name = self.get_class().get_name()
         method_name = self.get_name()
@@ -1443,6 +1449,11 @@ class DexClass:
         self.demangled = None
         self.method_mapping = None
 
+    def __len__(self):
+        return sum((len(m) for m in self.get_methods())) + sum(
+            (len(f) for f in self.get_fields())
+        )
+
     def dump(self, options, f=sys.stdout):
         dex = self.get_dex()
         class_def_offset = self.class_def.get_offset()
@@ -1612,6 +1623,9 @@ class DexField:
         self.name_in_file = None
         self.name = None
         self.is_instance_field = is_instance_field
+
+    def __len__(self):
+        return len(self.encoded_field) if self.encoded_field else 0
 
     def get_signature(self):
         class_name = self.get_class().get_name()

--- a/tools/python/file_extract.py
+++ b/tools/python/file_extract.py
@@ -399,7 +399,7 @@ class FileExtract:
         """Extract a fixed length C string from the current file position."""
         s = self.read_size(n)
         if s:
-            cstr, = struct.unpack(self.byte_order + ("%i" % n) + "s", s)
+            (cstr,) = struct.unpack(self.byte_order + ("%i" % n) + "s", s)
             # Strip trialing NULLs
             cstr = cstr.strip(b"\0")
             if isprint_only_with_space_padding:
@@ -807,6 +807,10 @@ class AutoParser:
         self.context = context  # Any object you want to store for future usage
         self.max_name_len = 0
         self.extract_items(items, data)
+        self.__len = data.tell() - self.__offset
+
+    def __len__(self):
+        return self.__len
 
     def get_list_header_lines(self):
         """When an object of this type is in a list, print out this string


### PR DESCRIPTION
When using `dex.py` I found it useful to be able to calculate the size of a structure on disk. These `__len__` implementations give us that.