### PR TITLE
Fix call to append on bytes

### DIFF
--- a/tools/hprof/dump_classes_from_hprof.py
+++ b/tools/hprof/dump_classes_from_hprof.py
@@ -34,7 +34,7 @@ def parse_hprof_dump(instream):
             break
         if byte == b"\x00":
             break
-        tag.append(byte)
+        tag += byte
     tag = tag.decode("utf-8")  # UTF8 should be close enough to modified UTF8.
 
     big_endian_unsigned_4byte_integer = struct.Struct(b">I")


### PR DESCRIPTION
Summary:
Introduced in a recent refactoring, which changed a call to `operator.concat`
with a call to `append`, which does not exist on bytestrings or strings.  I
think the equivalent code should use `+=` instead.

Reviewed By: geralt-encore

Differential Revision: D23128832

