### PR TITLE
Fix circle CI: no hash implementation for enums extending uint8_t on Ubuntu 16.04 gcc-5

### DIFF
--- a/service/dataflow/ConstantUses.h
+++ b/service/dataflow/ConstantUses.h
@@ -56,3 +56,15 @@ class ConstantUses {
 };
 
 } // namespace constant_uses
+
+namespace std {
+
+template <>
+struct hash<constant_uses::TypeDemand> {
+  std::size_t operator()(constant_uses::TypeDemand const& demand) const
+      noexcept {
+    return static_cast<size_t>(demand);
+  }
+};
+
+} // namespace std


### PR DESCRIPTION
Summary: As in title. Attempt to fix circle CI.

Differential Revision: D23845264

