### PR TITLE
Add FALLTHROUGH_INTENDED macro

### DIFF
--- a/libredex/DexInstruction.cpp
+++ b/libredex/DexInstruction.cpp
@@ -12,6 +12,7 @@
 #include "DexIdx.h"
 #include "DexMethodHandle.h"
 #include "DexOutput.h"
+#include "Macros.h"
 #include "Show.h"
 #include "Warning.h"
 
@@ -255,7 +256,7 @@ uint16_t DexInstruction::src(int i) const {
   case FMT_f22c_s:
     redex_assert(i < 2);
     if (i == 0) return (m_opcode >> 8) & 0xf;
-    if (i == 1) return (m_opcode >> 12) & 0xf;
+    return (m_opcode >> 12) & 0xf; // i == 1
   case FMT_f32x:
     redex_assert(i == 0);
     return m_arg[1];
@@ -791,6 +792,7 @@ DexInstruction* DexInstruction::make_instruction(DexIdx* idx,
     }
   }
   /* Format 10, fall through for NOP */
+    FALLTHROUGH_INTENDED;
   case DOPCODE_MOVE:
   case DOPCODE_MOVE_WIDE:
   case DOPCODE_MOVE_OBJECT:

--- a/libredex/DexLoader.cpp
+++ b/libredex/DexLoader.cpp
@@ -11,6 +11,7 @@
 #include "DexDefs.h"
 #include "DexMethodHandle.h"
 #include "IRCode.h"
+#include "Macros.h"
 #include "Trace.h"
 #include "Walkers.h"
 #include "WorkQueue.h"
@@ -32,11 +33,11 @@ static void validate_dex_header(const dex_header* dh,
   case 38:
     supported = supported ||
                 !memcmp(dh->magic, DEX_HEADER_DEXMAGIC_V38, sizeof(dh->magic));
-    /* intentional fallthrough to also check for v37 */
+    FALLTHROUGH_INTENDED; /* intentional fallthrough to also check for v37 */
   case 37:
     supported = supported ||
                 !memcmp(dh->magic, DEX_HEADER_DEXMAGIC_V37, sizeof(dh->magic));
-    /* intentional fallthrough to also check for v35 */
+    FALLTHROUGH_INTENDED; /* intentional fallthrough to also check for v35 */
   case 35:
     supported = supported ||
                 !memcmp(dh->magic, DEX_HEADER_DEXMAGIC_V35, sizeof(dh->magic));

--- a/libredex/Macros.h
+++ b/libredex/Macros.h
@@ -29,3 +29,19 @@
 #define ATTRIBUTE_UNUSED
 
 #endif
+
+// [[fallthrough]]; is standard with C++17. Until then, use specifics.
+#ifndef FALLTHROUGH_INTENDED
+#if __cplusplus >= 201703L
+#define FALLTHROUGH_INTENDED [[fallthrough]]
+#elif defined(__clang__)
+#define FALLTHROUGH_INTENDED [[clang::fallthrough]]
+#elif defined(__GNUC__) && (__GNUC__ >= 7)
+// Note: GCC also scans comments with a regex, but let's ignore that.
+#define FALLTHROUGH_INTENDED [[gcc::fallthrough]]
+#else
+#define FALLTHROUGH_INTENDED \
+  do {                       \
+  } while (false)
+#endif
+#endif // FALLTHROUGH_INTENDED

--- a/libredex/PointsToSemantics.cpp
+++ b/libredex/PointsToSemantics.cpp
@@ -36,6 +36,7 @@
 #include "IRCode.h"
 #include "IRInstruction.h"
 #include "IROpcode.h"
+#include "Macros.h"
 #include "PatriciaTreeMapAbstractEnvironment.h"
 #include "PatriciaTreeSetAbstractDomain.h"
 #include "PointsToSemanticsUtils.h"
@@ -776,8 +777,8 @@ class AnchorPropagation final : public BaseIRAnalyzer<AnchorEnvironment> {
       current_state->set(insn->dest(), current_state->get(insn->src(0)));
       break;
     }
-    case IOPCODE_MOVE_RESULT_PSEUDO_OBJECT: {
-    case OPCODE_MOVE_RESULT_OBJECT:
+    case IOPCODE_MOVE_RESULT_PSEUDO_OBJECT:
+    case OPCODE_MOVE_RESULT_OBJECT: {
       current_state->set(insn->dest(), current_state->get(RESULT_REGISTER));
       break;
     }
@@ -1026,6 +1027,7 @@ class PointsToActionGenerator final {
       }
       // Otherwise, we fall through to the generic case.
     }
+      FALLTHROUGH_INTENDED;
     case OPCODE_NEW_ARRAY:
     case OPCODE_FILLED_NEW_ARRAY: {
       m_semantics->add(PointsToAction::load_operation(

--- a/opt/outliner/OutlinerTypeAnalysis.cpp
+++ b/opt/outliner/OutlinerTypeAnalysis.cpp
@@ -8,6 +8,7 @@
 #include "OutlinerTypeAnalysis.h"
 
 #include "DexTypeEnvironment.h"
+#include "Macros.h"
 #include "Show.h"
 #include "StlUtil.h"
 
@@ -914,7 +915,7 @@ const DexType* OutlinerTypeAnalysis::get_const_insns_type_demand(
           type_demands.insert(type::_int());
           break;
         }
-        // fallthrough
+        FALLTHROUGH_INTENDED;
       default:
         type_demands.insert(get_type_demand(p.first, p.second));
         break;

--- a/opt/peephole/Peephole.cpp
+++ b/opt/peephole/Peephole.cpp
@@ -696,6 +696,7 @@ struct Matcher {
           break;
         case Field::B:
           replace->set_field(matched_fields.at(Field::B));
+          break;
         default:
           not_reached_log("Unexpected field directive 0x%x",
                           replace_info.field);

--- a/service/copy-propagation/CopyPropagation.cpp
+++ b/service/copy-propagation/CopyPropagation.cpp
@@ -391,6 +391,7 @@ class AliasFixpointIterator final
           }
         }
       }
+      break;
     default:
       break;
     }

--- a/service/method-inliner/Inliner.cpp
+++ b/service/method-inliner/Inliner.cpp
@@ -25,6 +25,7 @@
 #include "InlineForSpeed.h"
 #include "InlinerConfig.h"
 #include "LocalDce.h"
+#include "Macros.h"
 #include "MethodProfiles.h"
 #include "Mutators.h"
 #include "OptData.h"
@@ -2229,6 +2230,7 @@ class MethodSplicer {
         return true;
       }
     }
+      FALLTHROUGH_INTENDED;
     default:
       return false;
     }


### PR DESCRIPTION
Summary: Add a macro to emit the right supported attribute for switch case fallthrough annotation. Fix up issues.

Differential Revision: D24119246

