### PR TITLE
Add SDK cache to CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,19 +36,69 @@ commands:
             sudo ln -s /usr/bin/dalvik-exchange /usr/local/bin/dx
 
   # Special version of the above to work around Debian Testing package issues.
+  #
+  # Note: CircleCI does not allow to drop existing caches (in case they are
+  #       outdated, for example). The expectation is that the "cache key"
+  #       changes, for example via the checksum of a dependency file.
+  #
+  #       This does not apply to our setup. So we use an environment variable
+  #       defined in the project settings. If a cache needs to be invalidated,
+  #       update the variable value.
+  #
+  #       However, at the same time the project settings values cannot be used
+  #       directly. So use a file as an intermediate.
+  #
+  #       See:
+  #       * [https://support.circleci.com/hc/en-us/articles/115015426888-Clear-project-dependency-cache]
+  #       * [https://devops.stackexchange.com/questions/9147/how-to-get-other-than-no-value-when-interpolating-environment-some-var]
   test-build-setup-sdk:
     steps:
       - run:
           name: Setup for tests (Deb Testing)
           command: |
             sudo apt-get install -y --no-install-recommends default-jdk-headless
+
+      - run:
+          name: Create cache key file
+          command: |
+            echo "Cache key is: ${CACHE_VERSION}"
+            echo "${CACHE_VERSION}" > cache_version.rev
+
+      - restore_cache:
+          keys:
+            - android-build-tools-{{ checksum "cache_version.rev" }}
+
+      # We have to emulate cache behavior. Skip downloads if files exist.
+      - run:
+          name: Check/Install (SDK)
+          command: |
+            if [ -e ~/sdk/build-tools/25.0.3/dx ] ; then
+              echo "Found SDK."
+              exit 0
+            fi
+            echo "SDK missing, downloading..."
+            rm -rf ~/sdk 2>/dev/null
             wget https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip
             mkdir -p ~/sdk/cmdline-tools
             unzip commandlinetools-linux-6609375_latest.zip -d ~/sdk/cmdline-tools/
-            pushd ~/sdk/cmdline-tools/tools/bin
+            pushd ~/sdk/cmdline-tools/tools/bin >/dev/null
             echo 'y' | ./sdkmanager --install 'build-tools;25.0.3'
-            popd
+            popd >/dev/null
+
+      - run:
+          name: Check/Install (Symlink)
+          command: |
+            if [ -L /usr/local/bin/dx ] ; then
+              echo "Found symlink."
+              exit 0
+            fi
+            echo "Adding symlink..."
             sudo ln -s ~/sdk/build-tools/25.0.3/dx /usr/local/bin/dx
+
+      - save_cache:
+          paths:
+            - ~/sdk
+          key: android-build-tools-{{ checksum "cache_version.rev" }}
 
   configure-and-build-w-make:
     parameters:


### PR DESCRIPTION
Summary: Try to avoid downloading the SDK over and over.

Differential Revision: D24144890

