### PR TITLE
clang-tidy config inheritance was added for redex project

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,13 +1,22 @@
-Checks: >
-  -*,
-  bugprone-*,-bugprone-narrowing-conversions,-bugprone-too-small-loop-variable,bugprone-macro-parentheses,
-  modernize-make-shared,
-  performance-*,-performance-inefficient-string-concatenation,
-  readability-const-return-type,readability-container-size-empty,readability-redundant-*,
-  misc-definitions-in-headers,
-  modernize-use-override,modernize-use-using,
-  google-explicit-constructor,hicpp-explicit-conversions,
-  llvm-namespace-comment
+---
+# NOTE there must be no spaces before the '-', so put the comma last.
+InheritParentConfig: true
+Checks: '
+bugprone-*,
+-bugprone-narrowing-conversions,
+-bugprone-too-small-loop-variable,
+bugprone-macro-parentheses,
+modernize-make-shared,
+performance-*,
+-performance-inefficient-string-concatenation,
+readability-const-return-type,
+readability-container-size-empty,
+readability-redundant-*,
+misc-definitions-in-headers,
+modernize-use-override,modernize-use-using,
+google-explicit-constructor,hicpp-explicit-conversions,
+llvm-namespace-comment,
+'
 WarningsAsErrors: '*'
 CheckOptions:
   - key: modernize-use-override.IgnoreDestructors


### PR DESCRIPTION
Summary: The diff adds clang-tidy inheritance for `.clang-tidy` configs.

Differential Revision: D25221045

