### PR TITLE
Package redex in cmake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,6 +195,11 @@ commands:
           shell: bash.exe
           command: 'build/redex-all --show-passes | grep -E "Registered passes: [1-9][0-9]*"'
 
+      - run:
+          name: Package
+          shell: c:/tools/msys64/msys2_shell.cmd -defterm -no-start -mingw64 -full-path -here -c
+          command: cd build && make -j 4 package
+
 jobs:
   build-16_04:
     docker:
@@ -257,12 +262,12 @@ jobs:
       - setup-build-and-test-windows
 
       - run:
-          name: Zip redex-all
+          name: Copy package for CircleCI
           shell: c:/tools/msys64/msys2_shell.cmd -defterm -no-start -mingw64 -full-path -here -c
-          command: cp build/redex-all.exe . && cp config/default.config . &&  zip -r -9 redex.zip LICENSE default.config redex-all.exe redex.py pyredex && ls -l redex.zip && unzip -l redex.zip
+          command: mkdir artifacts && mv build/Redex*.zip artifacts/
 
       - store_artifacts:
-          path: .\redex.zip
+          path: .\artifacts
 
   deploy-website:
     docker:
@@ -308,7 +313,7 @@ workflows:
           filters: *filter-not-gh-pages-not-master
       - build-deb_testing:
           filters: *filter-not-gh-pages-not-master
-      - build-windows:
+      - build-windows-artifacts:
           filters: *filter-not-gh-pages-not-master
 
   nightly:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,3 +126,17 @@ target_link_libraries(redex-all
 target_compile_definitions(redex-all PRIVATE)
 
 set_link_whole(redex-all redex)
+
+install(TARGETS redex-all DESTINATION .)
+
+# redex.py things...
+
+install(FILES redex.py DESTINATION .)
+install(DIRECTORY pyredex DESTINATION .)
+
+# Misc stuff, for good measure.
+install(FILES LICENSE README.md config/default.config DESTINATION .)
+
+set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)
+set(CPACK_GENERATOR "ZIP")
+include(CPack)


### PR DESCRIPTION
Summary: Add `install` and `CPack` support to the `cmake` definition, which will zip up things during `make package`.

Differential Revision: D25314217

