### PR TITLE
Package API level files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ commands:
       - run:
           name: Setup
           shell: c:/tools/msys64/msys2_shell.cmd -defterm -no-start -msys2 -full-path -here -c
-          command: pacman -S --needed --noconfirm make mingw-w64-x86_64-boost mingw-w64-x86_64-cmake mingw-w64-x86_64-gcc mingw-w64-x86_64-jsoncpp mingw-w64-x86_64-make zip unzip
+          command: pacman -S --needed --noconfirm make mingw-w64-x86_64-boost mingw-w64-x86_64-cmake mingw-w64-x86_64-gcc mingw-w64-x86_64-jsoncpp mingw-w64-x86_64-make zip unzip mingw-w64-x86_64-python
 
       - run:
           name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,17 @@ install(TARGETS redex-all DESTINATION .)
 install(FILES redex.py DESTINATION .)
 install(DIRECTORY pyredex DESTINATION .)
 
+file(GLOB gen_packed_apilevels "gen_packed_apilevels.py")
+file(GLOB api_level_srcs "service/api-levels/framework_classes_api_*.txt")
+
+add_custom_command(
+    OUTPUT  generated_apilevels.py
+    COMMAND python3 ${gen_packed_apilevels} -o ${CMAKE_CURRENT_BINARY_DIR}/generated_apilevels.py ${api_level_srcs}
+    DEPENDS ${api_level_srcs} ${gen_packed_apilevels}
+)
+add_custom_target(generated_apilevels ALL DEPENDS generated_apilevels.py)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/generated_apilevels.py DESTINATION .)
+
 # Misc stuff, for good measure.
 install(FILES LICENSE README.md config/default.config DESTINATION .)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -403,11 +403,18 @@ redexdump_LDADD = \
 bin_SCRIPTS = redex apkutil
 CLEANFILES = redex
 
+# Embedded API level files.
+GEN_API_LEVELS_SCRIPT = gen_packed_apilevels.py
+GENERATED_API_LEVELS_MODULE = generated_apilevels.py
+$(GENERATED_API_LEVELS_MODULE): $(GEN_API_LEVELS_SCRIPT) service/api-levels/framework_classes_api_*.txt
+	python3 $(GEN_API_LEVELS_SCRIPT) -o $@ service/api-levels/framework_classes_api_*.txt
+
 PYTHON_SRCS := redex.py \
 	pyredex/__init__.py \
 	pyredex/logger.py \
 	pyredex/unpacker.py \
-	pyredex/utils.py
+	pyredex/utils.py \
+	$(GENERATED_API_LEVELS_MODULE)
 
 redex: redex-all $(PYTHON_SRCS)
 	$(srcdir)/bundle-redex.sh

--- a/bundle-redex.sh
+++ b/bundle-redex.sh
@@ -4,6 +4,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-tar czf redex.tar.gz redex-all redex.py pyredex/*.py
+if [ -f "generated_apilevels.py" ] ; then
+  GEN_APILEVELS_INPUT="generated_apilevels.py"
+else
+  GEN_APILEVELS_INPUT=
+fi
+
+tar czf redex.tar.gz redex-all redex.py pyredex/*.py $GEN_APILEVELS_INPUT
 cat selfextract.sh redex.tar.gz > redex
 chmod +x redex

--- a/gen_packed_apilevels.py
+++ b/gen_packed_apilevels.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import base64
+import io
+import logging
+import os
+import zipfile
+from collections import namedtuple
+
+
+try:
+    import lzma  # noqa(F401)
+    import tarfile
+
+    has_tar_lzma = True
+except ImportError:
+    has_tar_lzma = False
+
+
+Args = namedtuple("Args", ["inputs", "output", "tarxz"])
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate packed API levels python module"
+    )
+
+    parser.add_argument("api_files", nargs="+", help="API files")
+    parser.add_argument(
+        "-o",
+        "--out",
+        nargs=1,
+        type=os.path.realpath,
+        help="Generated python wrapper",
+    )
+    parser.add_argument(
+        "--force-zip",
+        action="store_true",
+        help="Force the use of zip, even when tar and lzma are available",
+    )
+
+    args = parser.parse_args()
+
+    global has_tar_lzma
+    return Args(args.api_files, args.out[0], has_tar_lzma and not args.force_zip)
+
+
+def compress_zip(inputs):
+    logging.info("Compressing as zip")
+    buf = io.BytesIO(b"")
+    with zipfile.ZipFile(buf, "w") as zf:
+        for input in inputs:
+            logging.info("Adding %s", input)
+            with open(input, "rb") as f:
+                zf.writestr(os.path.basename(input), f)
+    buf.seek(0)
+    return buf
+
+
+def compress_tar_xz(inputs):
+    logging.info("Compressing as tar.xz")
+    buf = io.BytesIO(b"")
+    tar = tarfile.open(fileobj=buf, mode="w:xz")
+
+    for input in inputs:
+        logging.info("Adding %s", input)
+        info = tar.gettarinfo(input)
+        info.name = os.path.basename(input)
+        with open(input, "rb") as f:
+            tar.addfile(info, fileobj=f)
+
+    tar.close()
+    buf.seek(0)
+    return buf
+
+
+def compress_and_base_64(inputs, tar_xz):
+    with compress_tar_xz(inputs) if tar_xz else compress_zip(inputs) as buf:
+        return base64.b64encode(buf.getbuffer())
+
+
+_FILE_TEMPLATE = """
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import base64
+import io
+import re
+
+{extra_imports}
+
+
+_BASE64BLOB = "{base64_blob}"
+
+
+{compression_specific_api}
+
+
+def get_api_level_file(level):
+    name = f"framework_classes_api_{{level}}.txt"
+    return _load(name)
+
+
+def get_api_levels():
+    name_re = re.compile(r"^framework_classes_api_(\\d+)\\.txt$")
+    return {{
+        int(match.group(1)) for name in _all() for match in [name_re.match(name)] if match
+    }}
+"""
+
+
+_TAR_XZ_IMPORTS = """
+import lzma  # noqa(F401)
+import tarfile
+"""
+_TAR_XZ_API = """
+_TAR = tarfile.open(mode="r:xz", fileobj=io.BytesIO(base64.b64decode(_BASE64BLOB)))
+
+
+def _load(name):
+    global _TAR
+    return _TAR.extractfile(name).read()
+
+
+def _all():
+    global _TAR
+    return _TAR.getnames()
+"""
+
+
+_ZIP_IMPORTS = "import zipfile"
+_ZIP_API = """
+_ZIP = zipfile.ZipFile(io.BytesIO(base64.b64decode(_BASE64BLOB)), "r")
+
+
+def _load(name):
+    global _ZIP
+    return _ZIP.read(names)
+
+
+def _all():
+    global _ZIP
+    return _ZIP.namelist()
+"""
+
+
+def write_py_wrapper(base_64_bytes_blob, filename, tar_xz):
+    base64_str = base_64_bytes_blob.decode("ascii")
+    with open(filename, "w") as f:
+        f.write(
+            _FILE_TEMPLATE.format(
+                extra_imports=_TAR_XZ_IMPORTS if tar_xz else _ZIP_IMPORTS,
+                base64_blob=base64_str,
+                compression_specific_api=_TAR_XZ_API if tar_xz else _ZIP_API,
+            )
+        )
+
+
+def main():
+    args = parse_args()
+    base64_blob = compress_and_base_64(args.inputs, args.tarxz)
+    write_py_wrapper(base64_blob, args.output, args.tarxz)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()


### PR DESCRIPTION
Summary:
Generate a Python module for the API level files.

As the files together have nontrivial size (about 50MB at the time of writing), compress the files with zip or lzma, depending on availability in the host Python. This makes the output slightly nonportable in case lzma is supported on the generating host but not the target.

The generated file contains the compressed files as a base64 text blob and provides a minimal API to get the file content. For lzma compression, the file is about 900KB at time of writing - it is unclear how to increase the compression level with the Python API, as manual experiments show it should be compressible to about 700K. For zip compression, the file is around 8MB.

Let `redex.py` scan the input arguments. In case no API levels argument is given at all, attempt to load the generated module and extract its files. In case the module cannot be loaded, only log a warning message. This makes the approach more robust and corresponds to the original behavior.

Differential Revision: D25314571

