### PR TITLE
[OSS/Docker] Install CA Certificates

### DIFF
--- a/setup_oss_toolchain.sh
+++ b/setup_oss_toolchain.sh
@@ -46,6 +46,7 @@ function install_from_apt {
         automake
         binutils-dev
         bzip2
+        ca-certificates
         g++
         libiberty-dev
         libjemalloc-dev


### PR DESCRIPTION
Our Docker image is currently failing to verify www.python.org's CA
certificate, because the certificates that ship with Xenial are too
old and need to be updated.

Make sure to update those certificates when setting up the OSS
environment