### PR TITLE
[Redex/MatchFlow] One more explicit tuple constructor invocation.

### DIFF
--- a/test/unit/MatchFlowTest.cpp
+++ b/test/unit/MatchFlowTest.cpp
@@ -31,8 +31,8 @@ DataFlowGraph::Edge Edge(LocationIx from_loc,
                          src_index_t src,
                          LocationIx to_loc,
                          IRInstruction* to_insn) {
-  DataFlowEdge::Node from{from_loc, from_insn};
-  DataFlowEdge::Node to{to_loc, to_insn};
+  DataFlowGraph::Node from{from_loc, from_insn};
+  DataFlowGraph::Node to{to_loc, to_insn};
   return DataFlowGraph::Edge(from, src, to);
 }
 } // namespace detail

--- a/test/unit/MatchFlowTest.cpp
+++ b/test/unit/MatchFlowTest.cpp
@@ -31,7 +31,9 @@ DataFlowGraph::Edge Edge(LocationIx from_loc,
                          src_index_t src,
                          LocationIx to_loc,
                          IRInstruction* to_insn) {
-  return DataFlowGraph::Edge({from_loc, from_insn}, src, {to_loc, to_insn});
+  DataFlowEdge::Node from{from_loc, from_insn};
+  DataFlowEdge::Node to{to_loc, to_insn};
+  return DataFlowGraph::Edge(from, src, to);
 }
 } // namespace detail
 


### PR DESCRIPTION
Missed in #578 because the OSS tests were not run.

Test Plan:
Test in CI (wait for all green before landing).