### PR TITLE
Modified CMakeLists for MSYS2 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,7 @@ file(GLOB api_level_srcs "service/api-levels/framework_classes_api_*.txt")
 
 add_custom_command(
     OUTPUT  generated_apilevels.py
-    COMMAND python3 ${gen_packed_apilevels} -o ${CMAKE_CURRENT_BINARY_DIR}/generated_apilevels.py ${api_level_srcs}
+    COMMAND python3 ${gen_packed_apilevels} -o generated_apilevels.py ${api_level_srcs}
     DEPENDS ${api_level_srcs} ${gen_packed_apilevels}
 )
 add_custom_target(generated_apilevels ALL DEPENDS generated_apilevels.py)


### PR DESCRIPTION
Closes #581 
It happens that, when using _MSYS2_ the `${CMAKE_CURRENT_BINARY_DIR}` string is not consistent neither with _Unix_ path specifications nor _Windows_ path specifications. In this way, that variable should not be used as an input parameter to the _Python_ argument parser.