### PR TITLE
Make GNU make compilation more quiet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ commands:
           # The old Travis limit. Hopefully ensures GCC does
           # not die.
           command: |
-            make -j4
+            make -j4 V=0
 
   # Build & run tests.
   test-w-make:
@@ -135,13 +135,13 @@ commands:
       - run:
           name: Build tests
           command: |
-            make -j4 check TESTS=
+            make -j4 check TESTS= V=0
       - run:
           name: Run tests
           command: |
             mkdir -p /tmp/test-results
             export GTEST_OUTPUT=xml:/tmp/test-results/
-            make -j4 check
+            make -j4 check V=0
       - store_test_results:
           path: /tmp/test-results
 
@@ -194,7 +194,7 @@ commands:
       - run:
           name: Build
           shell: c:/tools/msys64/msys2_shell.cmd -defterm -no-start -mingw64 -full-path -here -c
-          command: mkdir build && cd build && cmake -G "MSYS Makefiles" .. && make -j 4
+          command: mkdir build && cd build && cmake -G "MSYS Makefiles" .. && make -j 4 V=0
 
       - run:
           name: Minimal Test
@@ -205,7 +205,7 @@ commands:
       - run:
           name: Package
           shell: c:/tools/msys64/msys2_shell.cmd -defterm -no-start -mingw64 -full-path -here -c
-          command: cd build && make -j 4 package
+          command: cd build && make -j 4 package V=0
 
 jobs:
   build-16_04:

--- a/setup_oss_toolchain.sh
+++ b/setup_oss_toolchain.sh
@@ -32,7 +32,7 @@ function install_python36_from_source {
     pushd Python-3.6.10
 
     ./configure
-    make && make install
+    make V=0 && make install V=0
 }
 
 function install_boost_from_source {


### PR DESCRIPTION
Summary: Avoid the verbose compilation that prints every compilation statement.

Differential Revision: D26836471

