### PR TITLE
Cache boost sources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,11 +20,27 @@ orbs:
 commands:
   # Setup. Includes boost.
   base-build-setup:
+    parameters:
+      save_boost_cache:
+        type: boolean
+        default: false
     steps:
+      # It is OK to generically restore boost, even if it is not used.
+      - restore_cache:
+          keys:
+            - boost-1-71-0-v1
       - run:
           name: Setup
           command: |
             sudo ./setup_oss_toolchain.sh
+      # Only save the cache when asked, e.g., hopefully when it was populated.
+      - when:
+          condition: << parameters.save_boost_cache >>
+          steps:
+            - save_cache:
+                paths:
+                  - boost_cache
+                key: boost-1-71-0-v1
 
   # For testing, need additional dependencies not provided by the image.
   test-build-setup:
@@ -151,8 +167,12 @@ commands:
       configure_extra:
         default: ""
         type: string
+      save_boost_cache:
+        type: boolean
+        default: false
     steps:
-      - base-build-setup
+      - base-build-setup:
+          save_boost_cache: << parameters.save_boost_cache >>
       - test-build-setup
 
       - configure-and-build-w-make:
@@ -166,8 +186,12 @@ commands:
       configure_extra:
         default: ""
         type: string
+      save_boost_cache:
+        type: boolean
+        default: false
     steps:
-      - base-build-setup
+      - base-build-setup:
+          save_boost_cache: << parameters.save_boost_cache >>
       - test-build-setup-sdk
 
       - configure-and-build-w-make:
@@ -224,7 +248,8 @@ jobs:
     resource_class: large
     steps:
       - checkout
-      - setup-build-and-test-w-make
+      - setup-build-and-test-w-make:
+          save_boost_cache: true
 
   build-deb_stable:
     docker:


### PR DESCRIPTION
Summary: Avoid hitting the boost servers, which have been flaky, lately.

Differential Revision: D28168302

