### PR TITLE
Fix jsoncpp library path for static builds

### DIFF
--- a/cmake_modules/Commons.cmake
+++ b/cmake_modules/Commons.cmake
@@ -41,7 +41,9 @@ macro(add_dependent_packages_for_redex)
 
     if(ENABLE_STATIC)
         set(Boost_USE_STATIC_LIBS ON)
-        set(Boost_USE_STATIC_RUNTIME ON)
+        if(NOT APPLE)
+            set(Boost_USE_STATIC_RUNTIME ON)
+        endif()
         set(Boost_USE_MULTITHREADED ON)
     endif()
 

--- a/cmake_modules/Commons.cmake
+++ b/cmake_modules/Commons.cmake
@@ -55,12 +55,15 @@ macro(add_dependent_packages_for_redex)
     print_dirs("${JSONCPP_INCLUDE_DIRS}" "JSONCPP_INCLUDE_DIRS")
 
     if(ENABLE_STATIC)
-        set(REDEX_JSONCPP_LIBRARY ${JSONCPP_LIBRARY_STATIC})
-        if (MINGW)
+        if (MINGW AND (EXISTS "${JSONCPP_INCLUDE_DIRS}/../lib/libjsoncpp.a"))
             # MSYS's JSONCPP only gets detected as shared, leaving the value
             # above empty. Hardcode as a workaround.
             set(REDEX_JSONCPP_LIBRARY ${JSONCPP_INCLUDE_DIRS}/../lib/libjsoncpp.a)
-        endif (MINGW)
+        elseif (JSONCPP_LIBRARY_STATIC)
+            set(REDEX_JSONCPP_LIBRARY ${JSONCPP_LIBRARY_STATIC})
+        else ()
+            message(FATAL_ERROR "Could not find a static library for JsonCpp.")
+        endif()
     else()
         set(REDEX_JSONCPP_LIBRARY ${JSONCPP_LIBRARY})
     endif()

--- a/cmake_modules/FindJsonCpp.cmake
+++ b/cmake_modules/FindJsonCpp.cmake
@@ -343,6 +343,11 @@ if(NOT JSONCPP_FOUND)
 		endif()
 	endif() # end of old logic
 
+	set(_JSONCPP_STATIC_LIB_NAMES "")
+	foreach(name ${_JSONCPP_LIB_NAMES})
+		list(APPEND _JSONCPP_STATIC_LIB_NAMES "lib${name}.a")
+	endforeach()
+
 	# Actually go looking.
 	find_path(JsonCpp_INCLUDE_DIR
 		NAMES
@@ -352,6 +357,12 @@ if(NOT JSONCPP_FOUND)
 	find_library(JsonCpp_LIBRARY
 		NAMES
 		${_JSONCPP_LIB_NAMES}
+		PATHS libs
+		PATH_SUFFIXES ${_JSONCPP_PATHSUFFIXES}
+		HINTS ${_JSONCPP_LIB_HINTS})
+	find_library(JsonCpp_STATIC_LIBRARY
+		NAMES
+		${_JSONCPP_STATIC_LIB_NAMES}
 		PATHS libs
 		PATH_SUFFIXES ${_JSONCPP_PATHSUFFIXES}
 		HINTS ${_JSONCPP_LIB_HINTS})
@@ -377,6 +388,12 @@ if(NOT JSONCPP_FOUND)
 		set(JSONCPP_LIBRARY "${JsonCpp_LIBRARY}")
 		set(JSONCPP_INCLUDE_DIRS "${JsonCpp_INCLUDE_DIR}")
 		unset(JSONCPP_LIBRARY_IS_SHARED)
+
+		if(JsonCpp_STATIC_LIBRARY)
+			set(JSONCPP_LIBRARY_STATIC "${JsonCpp_STATIC_LIBRARY}")
+		else()
+			unset(JSONCPP_LIBRARY_STATIC)
+		endif()
 
 		if(__jsoncpp_have_interface_support AND NOT TARGET jsoncpp_interface)
 			add_library(jsoncpp_interface INTERFACE)


### PR DESCRIPTION
Summary:
When building redex with `-DBUILD_TYPE=Static`, we should be linking against static libraries (i.e, `.a` on macOS).
The problem is that the JsonCpp finder does not look for the static library and cmake silently goes on.
We end up getting a link time error with jsoncpp symbols missing.

This patch adds proper logic to find the static library for JsonCpp and error when it is not found.

Reviewed By: dkgi

Differential Revision: D28733019

