### PR TITLE
Add class_skip_list config to ir_type_checker

### DIFF
--- a/libredex/IRTypeChecker.cpp
+++ b/libredex/IRTypeChecker.cpp
@@ -656,7 +656,7 @@ void validate_access(const DexMethod* accessor, const DexMember* accessee) {
 
 IRTypeChecker::~IRTypeChecker() {}
 
-IRTypeChecker::IRTypeChecker(DexMethod* dex_method, bool validate_access, std::unordered_set<std::string> class_skip_list)
+IRTypeChecker::IRTypeChecker(DexMethod* dex_method, bool validate_access, const std::unordered_set<std::string>& class_skip_list)
     : m_dex_method(dex_method),
       m_validate_access(validate_access),
       m_complete(false),

--- a/libredex/IRTypeChecker.cpp
+++ b/libredex/IRTypeChecker.cpp
@@ -656,7 +656,10 @@ void validate_access(const DexMethod* accessor, const DexMember* accessee) {
 
 IRTypeChecker::~IRTypeChecker() {}
 
-IRTypeChecker::IRTypeChecker(DexMethod* dex_method, bool validate_access, const std::unordered_set<std::string>& class_skip_list)
+IRTypeChecker::IRTypeChecker(
+    DexMethod* dex_method,
+    bool validate_access,
+    const std::unordered_set<std::string>& class_skip_list)
     : m_dex_method(dex_method),
       m_validate_access(validate_access),
       m_complete(false),
@@ -720,10 +723,11 @@ void IRTypeChecker::run() {
           << " at instruction '" << SHOW(insn) << "' @ " << std::hex
           << static_cast<const void*>(&mie) << " for " << e.what();
       m_what = out.str();
-      if (m_class_skip_list.count(m_dex_method->get_class()->get_name()->str()) <= 0) {
-          m_good = false;
-          m_complete = true;
-          return;
+      if (m_class_skip_list.count(
+              m_dex_method->get_class()->get_name()->str()) <= 0) {
+        m_good = false;
+        m_complete = true;
+        return;
       }
     }
   }

--- a/libredex/IRTypeChecker.cpp
+++ b/libredex/IRTypeChecker.cpp
@@ -718,7 +718,7 @@ void IRTypeChecker::run() {
       std::ostringstream out;
       out << "Type error in method " << m_dex_method->get_deobfuscated_name()
           << " at instruction '" << SHOW(insn) << "' @ " << std::hex
-          << static_cast<const void*>(&mie) << " for " << e.what() << std::endl;
+          << static_cast<const void*>(&mie) << " for " << e.what();
       m_what = out.str();
       if (m_class_skip_list.count(m_dex_method->get_class()->get_name()->str()) <= 0) {
           m_good = false;

--- a/libredex/IRTypeChecker.h
+++ b/libredex/IRTypeChecker.h
@@ -34,7 +34,7 @@ class IRTypeChecker final {
 
   explicit IRTypeChecker(DexMethod* dex_method,
                          bool validate_access = false,
-                         std::unordered_set<std::string> class_skip_list = {
+                         const std::unordered_set<std::string>& class_skip_list = {
                              ""});
 
   IRTypeChecker(const IRTypeChecker&) = delete;

--- a/libredex/IRTypeChecker.h
+++ b/libredex/IRTypeChecker.h
@@ -32,7 +32,10 @@ class IRTypeChecker final {
   // definition must be located after the definition of TypeInference.
   ~IRTypeChecker();
 
-  explicit IRTypeChecker(DexMethod* dex_method, bool validate_access = false);
+  explicit IRTypeChecker(DexMethod* dex_method,
+                         bool validate_access = false,
+                         std::unordered_set<std::string> class_skip_list = {
+                             ""});
 
   IRTypeChecker(const IRTypeChecker&) = delete;
 
@@ -133,6 +136,7 @@ class IRTypeChecker final {
   bool m_good;
   std::string m_what;
   std::unique_ptr<type_inference::TypeInference> m_type_inference;
+  std::unordered_set<std::string> m_class_skip_list;
 
   friend std::ostream& operator<<(std::ostream&, const IRTypeChecker&);
 };

--- a/libredex/IRTypeChecker.h
+++ b/libredex/IRTypeChecker.h
@@ -32,10 +32,10 @@ class IRTypeChecker final {
   // definition must be located after the definition of TypeInference.
   ~IRTypeChecker();
 
-  explicit IRTypeChecker(DexMethod* dex_method,
-                         bool validate_access = false,
-                         const std::unordered_set<std::string>& class_skip_list = {
-                             ""});
+  explicit IRTypeChecker(
+      DexMethod* dex_method,
+      bool validate_access = false,
+      const std::unordered_set<std::string>& class_skip_list = {});
 
   IRTypeChecker(const IRTypeChecker&) = delete;
 

--- a/libredex/PassManager.cpp
+++ b/libredex/PassManager.cpp
@@ -207,7 +207,7 @@ struct CheckerConfig {
                                                    bool verify_moves,
                                                    bool check_no_overwrite_this,
                                                    bool validate_access,
-                                                   const std::unordered_set<std::string> class_skip_list,
+                                                   const std::unordered_set<std::string>& class_skip_list,
                                                    bool exit_on_fail = true) {
     TRACE(PM, 1, "Running IRTypeChecker...");
     Timer t("IRTypeChecker");

--- a/libredex/PassManager.cpp
+++ b/libredex/PassManager.cpp
@@ -203,12 +203,13 @@ struct CheckerConfig {
   }
 
   // TODO(fengliu): Kill the `validate_access` flag.
-  static boost::optional<std::string> run_verifier(const Scope& scope,
-                                                   bool verify_moves,
-                                                   bool check_no_overwrite_this,
-                                                   bool validate_access,
-                                                   const std::unordered_set<std::string>& class_skip_list,
-                                                   bool exit_on_fail = true) {
+  static boost::optional<std::string> run_verifier(
+      const Scope& scope,
+      bool verify_moves,
+      bool check_no_overwrite_this,
+      bool validate_access,
+      const std::unordered_set<std::string>& class_skip_list,
+      bool exit_on_fail = true) {
     TRACE(PM, 1, "Running IRTypeChecker...");
     Timer t("IRTypeChecker");
     std::atomic<size_t> errors{0};

--- a/opt/copy-propagation/CopyPropagationPass.cpp
+++ b/opt/copy-propagation/CopyPropagationPass.cpp
@@ -15,7 +15,7 @@
 using namespace copy_propagation_impl;
 
 void CopyPropagationPass::run_pass(DexStoresVector& stores,
-                                   ConfigFiles& /* unused */,
+                                   ConfigFiles& conf,
                                    PassManager& mgr) {
   auto scope = build_class_scope(stores);
 
@@ -31,7 +31,7 @@ void CopyPropagationPass::run_pass(DexStoresVector& stores,
   m_config.regalloc_has_run = mgr.regalloc_has_run();
 
   CopyPropagation impl(m_config);
-  auto stats = impl.run(scope);
+  auto stats = impl.run(scope, conf);
   mgr.incr_metric("redundant_moves_eliminated", stats.moves_eliminated);
   mgr.incr_metric("source_regs_replaced_with_representative",
                   stats.replaced_sources);

--- a/service/copy-propagation/CopyPropagation.h
+++ b/service/copy-propagation/CopyPropagation.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "ConfigFiles.h"
 #include "IRCode.h"
 #include "Trace.h"
 
@@ -45,7 +46,7 @@ class CopyPropagation final {
  public:
   explicit CopyPropagation(const Config& config) : m_config(config) {}
 
-  Stats run(const Scope& scope);
+  Stats run(const Scope& scope, const ConfigFiles& conf);
 
   Stats run(IRCode*, DexMethod* = nullptr);
 


### PR DESCRIPTION
We have a use-case where our build has some poorly behaved bytecode manipulators that change things in a way that IR Type Checker does not like. There is no easy to way to fix them but they do not cause runtime errors so the easiest thing for us to do is to use a skip list for IR Type Checker to allow us to continue even if it finds things it doesn't like.

Example:
redex.config
```
{
  "ir_type_checker": {
    "class_skip_list": [
      "Lcom/some/class;",
      "Lcom/some/other/class;"
    ]
  }
}
```