### PR TITLE
Fix tests for mac

### DIFF
--- a/test/unit/ConcurrentContainersTest.cpp
+++ b/test/unit/ConcurrentContainersTest.cpp
@@ -53,7 +53,8 @@ class ConcurrentContainersTest : public ::testing::Test {
   std::vector<uint32_t> generate_random_subset(
       const std::vector<uint32_t>& data) {
     auto new_data = data;
-    std::random_shuffle(new_data.begin(), new_data.end());
+    unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
+    std::shuffle(new_data.begin(), new_data.end(), std::default_random_engine(seed));
     new_data.erase(new_data.begin(), new_data.begin() + m_size / 2);
     return new_data;
   }

--- a/test/unit/MethodInlineTest.cpp
+++ b/test/unit/MethodInlineTest.cpp
@@ -817,21 +817,21 @@ TEST_F(MethodInlineTest, boxed_boolean) {
     check_method = make_unboxing_precondition_method(foo_cls, "check");
     candidates.insert(check_method);
     // foo_main calls check_method a few times.
-    auto FALSE = (DexField*)DexField::get_field(
+    auto FALSE_field = (DexField*)DexField::get_field(
         "Ljava/lang/Boolean;.FALSE:Ljava/lang/Boolean;");
-    always_assert(FALSE != nullptr);
-    auto TRUE = (DexField*)DexField::get_field(
+    always_assert(FALSE_field != nullptr);
+    auto TRUE_field = (DexField*)DexField::get_field(
         "Ljava/lang/Boolean;.TRUE:Ljava/lang/Boolean;");
-    always_assert(TRUE != nullptr);
+    always_assert(TRUE_field != nullptr);
     foo_main = make_a_method_calls_others_with_arg(foo_cls,
                                                    "foo_main",
                                                    {
-                                                       {check_method, FALSE},
-                                                       {check_method, FALSE},
-                                                       {check_method, TRUE},
-                                                       {check_method, FALSE},
-                                                       {check_method, FALSE},
-                                                       {check_method, FALSE},
+                                                       {check_method, FALSE_field},
+                                                       {check_method, FALSE_field},
+                                                       {check_method, TRUE_field},
+                                                       {check_method, FALSE_field},
+                                                       {check_method, FALSE_field},
+                                                       {check_method, FALSE_field},
                                                    });
     expected_inlined.insert(check_method);
   }


### PR DESCRIPTION
On macs, `FALSE` and `TRUE` are already defined in `boolean.h` which causes an error when compiling and trying to assign to `auto FALSE` and `auto TRUE`.

For some reason, my build is also having an issue with `random_shuffle` not being found which would imply using c++17 even though all the documentation I can find indicates that the default should be c++14 for `Apple clang version 11.0.3 (clang-1103.0.32.62)`. I updated to use `shuffle` anyways which should work from c++11 onwards.