### PR TITLE
Expand proguard parsing for multilingual and dump

### DIFF
--- a/libredex/ProguardLexer.cpp
+++ b/libredex/ProguardLexer.cpp
@@ -35,7 +35,15 @@ bool is_deliminator(char ch) {
          ch == ',' || ch == ';' || ch == ':' || ch == EOF || ch == '#';
 }
 
+bool is_not_idenfitier_character(char ch) {
+  return ch == '=' || ch == '+' || ch == '|' || ch == '@' || ch == '#' ||
+         ch == '^' || ch == '&' || ch == '"' || ch == '\'' || ch == '`' ||
+         ch == '~' || ch == '-';
+}
+
 // An identifier can refer to a class name, a field name or a package name.
+// Unused: need to fully implement to java spec before using again.
+// https://docs.oracle.com/javase/specs/jls/se16/html/jls-3.html#jls-JavaLetter
 bool is_identifier_character(char ch) {
   return isalnum(ch) || ch == '_' || ch == '$' || ch == '*' || ch == '.' ||
          ch == '\'' || ch == '[' || ch == ']' || ch == '<' || ch == '>' ||
@@ -44,7 +52,11 @@ bool is_identifier_character(char ch) {
 
 bool is_identifier(const boost::string_view& ident) {
   for (const char& ch : ident) {
-    if (!is_identifier_character(ch)) {
+    // java identifiers can be multi-lingual so membership testing is complex.
+    // much simpler to test for what is definitely not an identifier and then
+    // assume everything else is a legal identifier char, accepting that we
+    // will have false positives.
+    if (is_deliminator(ch) || is_not_idenfitier_character(ch)) {
       return false;
     }
   }
@@ -305,6 +317,8 @@ std::string Token::show() const {
     return "-include";
   case TokenType::basedirectory:
     return "-basedirectory";
+  case TokenType::dump:
+    return "-dump";
   case TokenType::injars:
     return "-injars ";
   case TokenType::outjars:
@@ -447,6 +461,7 @@ bool Token::is_command() const {
   // Input/Output Options
   case TokenType::include:
   case TokenType::basedirectory:
+  case TokenType::dump:
   case TokenType::injars:
   case TokenType::outjars:
   case TokenType::libraryjars:
@@ -595,6 +610,7 @@ std::vector<Token> lex(const boost::string_view& in) {
       // Input/Output Options
       {"include", TokenType::include},
       {"basedirectory", TokenType::basedirectory},
+      {"dump", TokenType::dump},
       {"printmapping", TokenType::printmapping},
       {"printconfiguration", TokenType::printconfiguration},
       {"printseeds", TokenType::printseeds},

--- a/libredex/ProguardLexer.h
+++ b/libredex/ProguardLexer.h
@@ -68,6 +68,7 @@ enum class TokenType {
   // Input/Output Options
   include,
   basedirectory,
+  dump,
   injars,
   outjars,
   libraryjars,

--- a/test/unit/ProguardLexerTest.cpp
+++ b/test/unit/ProguardLexerTest.cpp
@@ -54,7 +54,7 @@ TEST(ProguardLexerTest, assortment) {
       "<init>(...);\n"
       "-keep class *#-keepnames class *\n"
       "-dontobfuscate\n"
-      "-dump some/path/dumpя.txt";
+      "-dump some/path/dumpя.txt\n";
   std::vector<std::pair<unsigned, TokenType>> expected = {
       {1, TokenType::openCurlyBracket},
       {1, TokenType::closeCurlyBracket},
@@ -146,7 +146,9 @@ TEST(ProguardLexerTest, assortment) {
       {22, TokenType::classToken},
       {22, TokenType::identifier},
       {23, TokenType::dontobfuscate},
-      {24, TokenType::eof_token},
+      {24, TokenType::dump},
+      {24, TokenType::filepath},
+      {25, TokenType::eof_token},
   };
   std::vector<Token> tokens = lex(s);
   EXPECT_EQ(tokens.size(), expected.size());

--- a/test/unit/ProguardLexerTest.cpp
+++ b/test/unit/ProguardLexerTest.cpp
@@ -32,11 +32,11 @@ TEST(ProguardLexerTest, assortment) {
       "strictfp synthetic bridge varargs wombat <init> <fields>\n"
       "<methods> []\n"
       "-target 1.8 \n"
-      "-include /alpha/beta.pro\n"
-      "-basedirectory /alpha/beta\n"
-      "-injars gamma.pro\n"
-      "-outjars delta.pro:/epsilon/iota.pro\n"
-      "-libraryjars /alpha/zeta.pro\n"
+      "-include /alpha/betaя.pro\n"
+      "-basedirectory /alphaя/beta\n"
+      "-injars gammaя.pro\n"
+      "-outjars delta.pro:/epsilon/iotaя.pro\n"
+      "-libraryjars /alpha/zetaя.pro\n"
       "-keepdirectories mydir/**\n"
       "-keep -keepclassmembernames -keepnames -keepnames "
       "-keepclasseswithmembernames\n"
@@ -50,10 +50,11 @@ TEST(ProguardLexerTest, assortment) {
       "-dontusemixedcaseclassnames -dontpreverify -printconfiguration "
       "-dontwarn\n"
       "-verbose -someothercommand\n"
-      "class com.google.android.gms.measurement.AppMeasurementService\n"
+      "class com.google.android.gms.measurement.AppяMeasurementService\n"
       "<init>(...);\n"
       "-keep class *#-keepnames class *\n"
-      "-dontobfuscate\n";
+      "-dontobfuscate\n"
+      "-dump some/path/dumpя.txt";
   std::vector<std::pair<unsigned, TokenType>> expected = {
       {1, TokenType::openCurlyBracket},
       {1, TokenType::closeCurlyBracket},


### PR DESCRIPTION
`-dump` is an option in proguard that we use but which wasn't supported by the parser and caused the proguard config to be rejected. So, we added support for dump into the parser.

In addition, we use multi-lingual external dependencies that have fields written in non-ascii text that, by Java spec, is legal but which isn't allowed by the proguard parser. Since writing an accurate port of Java's `Character.isJavaIdenfier*()` family of methods is non-trivial and error-prone, we instead took the path of checking against a small selection of illegal characters and then allowing anything isn't explicitly disallowed. This will allow some false-positives, but will result in the acceptance of multi-lingual proguard configurations.