### PR TITLE
Do not assume that RegAllocPass is always requested

### DIFF
--- a/libredex/PassManager.h
+++ b/libredex/PassManager.h
@@ -92,6 +92,9 @@ class PassManager {
 
   void record_running_regalloc() { m_regalloc_has_run = true; }
   bool regalloc_has_run() const { return m_regalloc_has_run; }
+  bool regalloc_will_run() const {
+    return !regalloc_has_run() && find_pass("RegAllocPass") != nullptr;
+  }
 
   void record_running_interdex() { m_interdex_has_run = true; }
   bool interdex_has_run() const { return m_interdex_has_run; }

--- a/opt/copy-propagation/CopyPropagationPass.cpp
+++ b/opt/copy-propagation/CopyPropagationPass.cpp
@@ -28,7 +28,7 @@ void CopyPropagationPass::run_pass(DexStoresVector& stores,
           "Ignoring eliminate_const_literals because verify-none is not "
           "enabled.");
   }
-  m_config.regalloc_has_run = mgr.regalloc_has_run();
+  m_config.regalloc_will_fix = !mgr.regalloc_has_run() && mgr.regalloc_will_run();
 
   CopyPropagation impl(m_config);
   auto stats = impl.run(scope);

--- a/service/copy-propagation/CopyPropagation.h
+++ b/service/copy-propagation/CopyPropagation.h
@@ -24,7 +24,7 @@ struct Config {
   bool debug{false};
 
   // this is set by PassManager, not by JsonWrapper
-  bool regalloc_has_run{false};
+  bool regalloc_will_fix{false};
 };
 
 struct Stats {

--- a/test/unit/CopyPropagationTest.cpp
+++ b/test/unit/CopyPropagationTest.cpp
@@ -94,7 +94,7 @@ TEST_F(CopyPropagationTest, noRemapRange) {
   code->set_registers_size(7);
 
   copy_propagation_impl::Config config;
-  config.regalloc_has_run = true;
+  config.regalloc_will_fix = false;
   CopyPropagation(config).run(code.get());
 
   auto expected_code = assembler::ircode_from_string(R"(
@@ -842,7 +842,7 @@ TEST_F(CopyPropagationTest, wideInvokeSources) {
   copy_propagation_impl::Config config;
   config.replace_with_representative = true;
   config.wide_registers = true;
-  config.regalloc_has_run = true;
+  config.regalloc_will_fix = false;
   CopyPropagation(config).run(code.get());
 
   auto expected_code = assembler::ircode_from_string(no_change);
@@ -929,7 +929,7 @@ TEST_F(CopyPropagationTest, ResueConst) {
   code->set_registers_size(4);
 
   copy_propagation_impl::Config config;
-  config.regalloc_has_run = false;
+  config.regalloc_will_fix = true;
   CopyPropagation(config).run(code, method);
 
   auto expected_code = assembler::ircode_from_string(R"(
@@ -1004,6 +1004,7 @@ TEST_F(CopyPropagationTest, lock_canonicalization) {
   code->set_registers_size(2);
 
   copy_propagation_impl::Config config;
+  config.regalloc_will_fix = true;
   CopyPropagation(config).run(code, method);
 
   auto expected_code = assembler::ircode_from_string(R"(
@@ -1053,7 +1054,7 @@ TEST_F(CopyPropagationTest, check_cast_workaround_exc) {
   code->set_registers_size(3);
 
   copy_propagation_impl::Config config;
-  config.regalloc_has_run = true;
+  config.regalloc_will_fix = false;
   config.replace_with_representative = true;
   config.eliminate_const_literals_with_same_type_demands = true;
   CopyPropagation(config).run(code, method);


### PR DESCRIPTION
`CopyPropagationPass` has a bad habit of assuming that if `RegAllocPass` has not yet run, that it will eventually run. This causes problems in situations when `RegAllocPass` is not going to be run (a custom config is provided) and `CopyPropagationPass` decides to make unsafe changes (e.g., modifying `/range` instructions).

Instead of only checking whether or not `RegAllocPass` has or has not run yet, we also include a check for whether or not `RegAllocPass` is a requested pass and do some minor refactoring to rename fields to make more sense with this new check.