### PR TITLE
Add protobuf support in OSS setup script for Ubuntu/Debian

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,6 +15,27 @@ AM_CPPFLAGS = $(COMMON_INCLUDES)
 noinst_LTLIBRARIES = libredex.la libopt.la
 
 #
+# build protobuf
+#
+
+proto_res_in = \
+	proto/Resources.proto \
+	proto/Configuration.proto
+
+protores/%.pb.cc protores/%.pb.h: proto/%.proto | mdir
+	$(PROTOC) --proto_path=$(dir $^) --cpp_out=$(top_srcdir)/protores $^
+
+# create a directory for compiled proto files
+
+mdir:
+	mkdir -p $(top_srcdir)/protores
+
+proto_res_header_out = $(addprefix protores/, $(notdir ${proto_res_in:.proto=.pb.h}))
+proto_res_body_out = $(addprefix protores/, $(notdir ${proto_res_in:.proto=.pb.cc}))
+
+BUILT_SOURCES = $(proto_res_header_out)
+
+#
 # libredex: the optimizer's guts
 #
 
@@ -228,7 +249,9 @@ libredex_la_SOURCES = \
 	shared/file-utils.cpp \
 	util/CommandProfiling.cpp \
 	util/JemallocUtil.cpp \
-	util/Sha1.cpp
+	util/Sha1.cpp \
+	protores/Resources.pb.cc \
+	protores/Configuration.pb.cc
 
 libredex_la_LIBADD = \
 	$(BOOST_FILESYSTEM_LIB) \
@@ -236,7 +259,8 @@ libredex_la_LIBADD = \
 	$(BOOST_REGEX_LIB) \
 	$(BOOST_IOSTREAMS_LIB) \
 	$(BOOST_THREAD_LIB) \
-	-lpthread
+	-lpthread \
+	$(LIBPROTOBUF_LIBS)
 
 #
 # libopt: the optimization passes
@@ -395,10 +419,12 @@ redex_all_LDADD = \
 	$(BOOST_FILESYSTEM_LIB) \
 	$(BOOST_SYSTEM_LIB) \
 	$(BOOST_REGEX_LIB) \
+	$(BOOST_IOSTREAMS_LIB) \
 	$(BOOST_PROGRAM_OPTIONS_LIB) \
 	$(BOOST_THREAD_LIB) \
 	-lpthread \
-	-ldl
+	-ldl \
+	$(LIBPROTOBUF_LIBS)
 
 redex_all_LDFLAGS = \
 	-rdynamic # function names in stack traces

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -124,4 +124,6 @@ COMMON_INCLUDES = \
 	-I$(top_srcdir)/tools/common \
 	-I$(top_srcdir)/tools/redexdump \
 	-I$(top_srcdir)/util \
-	-I/usr/include/jsoncpp
+	-I$(top_srcdir)/protores \
+	-I/usr/include/jsoncpp \
+	$(PROTOBUF_CXXFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,77 @@ AX_BOOST_THREAD
 AC_CHECK_LIB([z], [adler32], [], [AC_MSG_ERROR([Please install zlib])])
 AC_CHECK_LIB([jsoncpp], [main], [], [AC_MSG_ERROR([Please install jsoncpp])])
 
+AC_DEFINE(HAS_PROTOBUF)
+
+# proto compiler
+# allow users to specify the path to protobuf compiler
+# --with-protoc
+
+AC_ARG_WITH([protoc],
+    [AS_HELP_STRING([--with-protoc=/path/to/protoc],
+        [Location of the protobuf compiler.])],
+    [PROTOC="$withval"],
+    [ AS_IF([test "x${PROTOC}" == "x"],
+        [AC_PATH_PROG([PROTOC], [protoc], [no])])
+    ]
+)
+AS_IF([test "${PROTOC}" == "no"], [AC_MSG_ERROR([Protobuf compiler protoc not found.])])
+
+# protobuf libraries
+# allow users to specify the path to the protobuf libs
+# --with-protolib
+
+AC_ARG_WITH([protolib],
+    [AS_HELP_STRING([--with-protolib=/path/to/protolibs],
+        [Location of the protobuf lib dir.])],
+    [ # protobuf lib path set by user
+        LDFLAGS_ORIG=$LDFLAGS
+
+        # test protobuf
+        LDFLAGS="${LDFLAGS_ORIG} -L${withval}"
+        AC_LANG_PUSH([C++])
+        AC_CHECK_LIB([protobuf], [main], [
+            # library found
+            AC_SUBST([LIBPROTOBUF_LIBS], "-L${withval} -lprotobuf")],
+            [AC_MSG_ERROR([Protobuf libraries not found for user specified path.])]
+        )
+        AC_LANG_POP([C++])
+        # restore original LDFLAGS
+        LDFLAGS=$LDFLAGS_ORIG
+    ],
+    [ # check default search path
+        AC_CHECK_LIB([protobuf], [main], [
+            AC_SUBST([LIBPROTOBUF_LIBS], "-lprotobuf")],
+            [AC_MSG_ERROR([Protobuf libraries not found.])]
+        )
+    ]
+)
+
+# protobuf headers
+# allow users to specify the path to the protobuf headers
+# --with-protoheader
+
+AC_ARG_WITH([protoheader],
+    [AS_HELP_STRING([--with-protoheader=/path/to/protoheaders],
+        [Location of the protobuf include dir.])],
+    [ # protobuf header path set by user
+        CXXFLAGS_ORIG=$CXXFLAGS
+
+        # test protobuf header
+        CXXFLAGS="-std=gnu++17 ${CXXFLAGS_ORIG} -I${withval}"
+        AC_LANG_PUSH([C++])
+        AC_CHECK_HEADER([google/protobuf/io/coded_stream.h], [
+            # library found
+            AC_SUBST([PROTOBUF_CXXFLAGS], "-I${withval}")],
+            [AC_MSG_ERROR([Protobuf headers not found for user specified path.])]
+        )
+        AC_LANG_POP([C++])
+        # restore original CXXFLAGS
+        CXXFLAGS=$CXXFLAGS_ORIG
+    ],
+    []
+)
+
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h inttypes.h memory.h netinet/in.h stddef.h stdint.h stdlib.h string.h sys/time.h unistd.h])
 

--- a/setup_oss_toolchain.sh
+++ b/setup_oss_toolchain.sh
@@ -40,6 +40,16 @@ function install_boost_from_source {
     "$ROOT"/get_boost.sh
 }
 
+function install_protobuf3_from_source {
+    pushd "$TMP"
+    wget https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protobuf-cpp-3.17.3.tar.gz
+    tar -xvf --no-same-owner protobuf-cpp-3.17.3.tar.gz
+
+    pushd protobuf-3.17.3
+    ./configure
+    make V=0 && make install V=0
+}
+
 function install_from_apt {
   PKGS="autoconf
         autoconf-archive
@@ -70,9 +80,11 @@ function handle_debian {
         10)
             install_from_apt python3
             install_boost_from_source
+            install_protobuf3_from_source
             ;;
         *)
             install_from_apt ${BOOST_DEB_UBUNTU_PKGS} python3
+            install_protobuf3_from_source
             ;;
     esac
 }
@@ -83,13 +95,16 @@ function handle_ubuntu {
             install_from_apt
             install_python36_from_source
             install_boost_from_source
+            install_protobuf3_from_source
             ;;
         1[7-9]*)
             install_from_apt python3
             install_boost_from_source
+            install_protobuf3_from_source
             ;;
         2*)
             install_from_apt ${BOOST_DEB_UBUNTU_PKGS} python3
+            install_protobuf3_from_source
             ;;
         *)
             echo "Unsupported Ubuntu version $1"


### PR DESCRIPTION
Summary: Add script to support protobuf in the setup script for Ubuntu/Debian.

Reviewed By: agampe

Differential Revision: D29944591

