### PR TITLE
Added protobuf support for OSS Redex build (MacOS/Linux)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,6 +15,24 @@ AM_CPPFLAGS = $(COMMON_INCLUDES)
 noinst_LTLIBRARIES = libredex.la libopt.la
 
 #
+# build protobuf
+#
+if SET_PROTOBUF
+
+proto_res_in = \
+	proto/Resources.proto \
+	proto/Configuration.proto
+
+protores/%.pb.cc protores/%.pb.h: proto/%.proto | mdir ; $(PROTOC) --proto_path=$(dir $^) --cpp_out=$(top_srcdir)/protores $^
+mdir: ; mkdir -p $(top_srcdir)/protores
+
+proto_res_header_out = $(addprefix protores/, $(notdir ${proto_res_in:.proto=.pb.h}))
+proto_res_body_out = $(addprefix protores/, $(notdir ${proto_res_in:.proto=.pb.cc}))
+BUILT_SOURCES = $(proto_res_header_out)
+
+endif
+
+#
 # libredex: the optimizer's guts
 #
 
@@ -238,6 +256,15 @@ libredex_la_LIBADD = \
 	$(BOOST_THREAD_LIB) \
 	-lpthread
 
+if SET_PROTOBUF
+libredex_la_SOURCES += \
+	protores/Resources.pb.cc \
+	protores/Configuration.pb.cc
+
+libredex_la_LIBADD += \
+	$(LIBPROTOBUF_LIBS)
+endif
+
 #
 # libopt: the optimization passes
 #
@@ -395,10 +422,16 @@ redex_all_LDADD = \
 	$(BOOST_FILESYSTEM_LIB) \
 	$(BOOST_SYSTEM_LIB) \
 	$(BOOST_REGEX_LIB) \
+	$(BOOST_IOSTREAMS_LIB) \
 	$(BOOST_PROGRAM_OPTIONS_LIB) \
 	$(BOOST_THREAD_LIB) \
 	-lpthread \
 	-ldl
+
+if SET_PROTOBUF
+redex_all_LDADD += \
+	$(LIBPROTOBUF_LIBS)
+endif
 
 redex_all_LDFLAGS = \
 	-rdynamic # function names in stack traces

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -125,3 +125,9 @@ COMMON_INCLUDES = \
 	-I$(top_srcdir)/tools/redexdump \
 	-I$(top_srcdir)/util \
 	-I/usr/include/jsoncpp
+
+if SET_PROTOBUF
+COMMON_INCLUDES += \
+	-I$(top_srcdir)/protores \
+	$(PROTOBUF_CXXFLAGS)
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,89 @@ AX_BOOST_THREAD
 AC_CHECK_LIB([z], [adler32], [], [AC_MSG_ERROR([Please install zlib])])
 AC_CHECK_LIB([jsoncpp], [main], [], [AC_MSG_ERROR([Please install jsoncpp])])
 
+# check whether user enabled protobuf
+AC_ARG_ENABLE([protobuf],
+    [AS_HELP_STRING([--enable-protobuf],
+        [Enable the protobuf for AppBundle build])],
+    [ AC_DEFINE(HAS_PROTOBUF) ]
+)
+
+AS_IF([test "x$enable_protobuf" = "xyes"], [
+    # user enabled protobuf
+    # check if protobuf is installed
+
+    # proto compiler
+    # allow users to specify the path to protobuf compiler
+    # --with-protoc
+
+    AC_ARG_WITH([protoc],
+        [AS_HELP_STRING([--with-protoc=/path/to/protoc],
+            [Location of the protobuf compiler.])],
+        [PROTOC="$withval"],
+        [ AS_IF([test "x${PROTOC}" == "x"],
+            [AC_PATH_PROG([PROTOC], [protoc], [no])])
+        ]
+    )
+    AS_IF([test "${PROTOC}" == "no"], [AC_MSG_ERROR([Protobuf compiler protoc not found.])])
+
+    # protobuf libraries
+    # allow users to specify the path to the protobuf libs
+    # --with-protolib
+
+    AC_ARG_WITH([protolib],
+        [AS_HELP_STRING([--with-protolib=/path/to/protolibs],
+            [Location of the protobuf lib dir.])],
+        [ # protobuf lib path set by user
+            LDFLAGS_ORIG=$LDFLAGS
+
+            # test protobuf
+            LDFLAGS="${LDFLAGS_ORIG} -L${withval}"
+            AC_LANG_PUSH([C++])
+            AC_CHECK_LIB([protobuf], [main], [
+            # library found
+                AC_SUBST([LIBPROTOBUF_LIBS], "-L${withval} -lprotobuf")],
+                [AC_MSG_ERROR([Protobuf libraries not found for user specified path.])]
+            )
+            AC_LANG_POP([C++])
+            # restore original LDFLAGS
+            LDFLAGS=$LDFLAGS_ORIG
+        ],
+        [ # check default search path
+            AC_CHECK_LIB([protobuf], [main], [
+                AC_SUBST([LIBPROTOBUF_LIBS], "-lprotobuf")],
+                [AC_MSG_ERROR([Protobuf libraries not found.])]
+            )
+        ]
+    )
+
+    # protobuf headers
+    # allow users to specify the path to the protobuf headers
+    # --with-protoheader
+
+    AC_ARG_WITH([protoheader],
+        [AS_HELP_STRING([--with-protoheader=/path/to/protoheaders],
+            [Location of the protobuf include dir.])],
+        [ # protobuf header path set by user
+            CXXFLAGS_ORIG=$CXXFLAGS
+
+            # test protobuf header
+            CXXFLAGS="-std=gnu++17 ${CXXFLAGS_ORIG} -I${withval}"
+            AC_LANG_PUSH([C++])
+            AC_CHECK_HEADER([google/protobuf/io/coded_stream.h], [
+                # library found
+                AC_SUBST([PROTOBUF_CXXFLAGS], "-I${withval}")],
+                [AC_MSG_ERROR([Protobuf headers not found for user specified path.])]
+            )
+            AC_LANG_POP([C++])
+            # restore original CXXFLAGS
+            CXXFLAGS=$CXXFLAGS_ORIG
+        ],
+        []
+    )
+])
+AM_CONDITIONAL([SET_PROTOBUF],[test "x${enable_protobuf}" = "xyes"])
+
+
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h inttypes.h memory.h netinet/in.h stddef.h stdint.h stdlib.h string.h sys/time.h unistd.h])
 


### PR DESCRIPTION
Summary:
Added protobuf support for OSS Redex build on MacOS/Linux. Users are either
- Install protobuf with package manager (e.g. homebrew).
- Build protobuf from the source and specify the paths using --with- flags for autoconf.
- Use `--enable-protobuf` flag in the autoconf to enable AppBundle support.

Differential Revision: D29823973

