### PR TITLE
Fix CircleCI Windows Build

### DIFF
--- a/libredex/InteractiveDebugging.cpp
+++ b/libredex/InteractiveDebugging.cpp
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include "Macros.h"
+
 #if !defined(NDEBUG) && !IS_WINDOWS
 
 #include "InteractiveDebugging.h"

--- a/libredex/InteractiveDebugging.h
+++ b/libredex/InteractiveDebugging.h
@@ -7,11 +7,13 @@
 
 #pragma once
 
+#include "Macros.h"
+
+#if !defined(NDEBUG) && !IS_WINDOWS
+
 #include "ControlFlow.h"
 #include "DexClass.h"
 #include "IRCode.h"
-
-#if !defined(NDEBUG) && !IS_WINDOWS
 
 // The following APIs are intended to be called from the debugger (athough
 // there's no harm calling them from internal code if desired).

--- a/libredex/TraceContextAccess.h
+++ b/libredex/TraceContextAccess.h
@@ -7,9 +7,12 @@
 
 #pragma once
 
-#include "Trace.h"
+#include "Macros.h"
 
 #if !IS_WINDOWS
+
+#include "Trace.h"
+
 struct TraceContextAccess {
   static const TraceContext* get_s_context() { return TraceContext::s_context; }
 };


### PR DESCRIPTION
Summary:
D32436681 (https://github.com/facebook/redex/commit/6d04128c055f957eebcd1fb999f4160d7606c1a4) broke this, since it relies on the `IS_WINDOWS` macro to not build
certain things for Windows, and you need to include the `Macros.h` header to
pull in `IS_WINDOWS`.

Differential Revision: D32447223

