### PR TITLE
fix CircleCI error

### DIFF
--- a/libredex/Native.cpp
+++ b/libredex/Native.cpp
@@ -19,7 +19,7 @@
 #include "Trace.h"
 #include "Walkers.h"
 
-namespace fs = std::filesystem;
+namespace fs = boost::filesystem;
 
 namespace {
 
@@ -62,7 +62,7 @@ void SoLibrary::populate_functions() {
   // Native methods can be registered with RegisterNatives calls. Use specific
   // analyses to extract information.
 
-  auto registered_natives_opt = read_json_from_file(m_json_path);
+  auto registered_natives_opt = read_json_from_file(m_json_path.string());
 
   always_assert_log(
       registered_natives_opt, "File not opened: %s", m_json_path.c_str());

--- a/libredex/Native.h
+++ b/libredex/Native.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <filesystem>
+#include <boost/filesystem.hpp>
 
 #include "DexClass.h"
 
@@ -42,13 +42,13 @@ class Function {
 
 class SoLibrary {
  public:
-  SoLibrary(std::string name, std::filesystem::path json)
+  SoLibrary(std::string name, boost::filesystem::path json)
       : m_name(std::move(name)),
         m_json_path(std::move(json)),
         m_name_to_functions({}) {}
 
   std::string get_name() const { return m_name; }
-  std::filesystem::path get_json_path() const { return m_json_path; }
+  boost::filesystem::path get_json_path() const { return m_json_path; }
 
   void populate_functions();
   std::unordered_map<std::string, Function>& get_functions() {
@@ -68,11 +68,11 @@ class SoLibrary {
 
  private:
   std::string m_name;
-  std::filesystem::path m_json_path;
+  boost::filesystem::path m_json_path;
   std::unordered_map<std::string, Function> m_name_to_functions;
 };
 
-std::vector<SoLibrary> get_so_libraries(const std::filesystem::path& path);
+std::vector<SoLibrary> get_so_libraries(const boost::filesystem::path& path);
 
 struct NativeContext {
   static NativeContext build(const std::string& path_to_native_results,

--- a/test/unit/NativeTest.cpp
+++ b/test/unit/NativeTest.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <filesystem>
+#include <boost/filesystem.hpp>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -17,7 +17,7 @@ struct NativeTest : public RedexTest {};
 
 TEST_F(NativeTest, testJNIOutputParsing) {
   auto libs = native::get_so_libraries(
-      std::filesystem::path(std::getenv("native_jni_output_path")) /
+      boost::filesystem::path(std::getenv("native_jni_output_path")) /
       "JNI_OUTPUT");
 
   std::unordered_set<std::string> lib_names;
@@ -31,7 +31,7 @@ TEST_F(NativeTest, testJNIOutputParsing) {
 
 TEST_F(NativeTest, testBuildingContext) {
   auto path_to_native_results =
-      std::filesystem::path(std::getenv("native_jni_output_path")) /
+      boost::filesystem::path(std::getenv("native_jni_output_path")) /
       "JNI_OUTPUT";
 
   auto type = DexType::make_type("Lredex/JNIExample;");


### PR DESCRIPTION
Summary: It looks like I adopted C++17 too aggressively. `std::filesystem` doesn't have implicit string conversion on Windows MSYS2 and is completely missing from Ubuntu 18.04.

Differential Revision: D33107049

