### PR TITLE
Follow-up to D33847489

### DIFF
--- a/libredex/DexClass.cpp
+++ b/libredex/DexClass.cpp
@@ -250,6 +250,10 @@ void DexField::attach_annotation_set(std::unique_ptr<DexAnnotationSet> aset) {
   m_anno = std::move(aset);
 }
 
+std::unique_ptr<DexAnnotationSet> DexField::release_annotations() {
+  return std::move(m_anno);
+}
+
 DexDebugEntry::DexDebugEntry(uint32_t addr,
                              std::unique_ptr<DexDebugInstruction> insn)
     : type(DexDebugEntryType::Instruction), addr(addr), insn(std::move(insn)) {}
@@ -838,6 +842,10 @@ void DexMethod::attach_param_annotation_set(
                          "param %d annotation to method %s exists\n", paramno,
                          self_show().c_str());
   m_param_anno[paramno] = std::move(aset);
+}
+
+std::unique_ptr<DexAnnotationSet> DexMethod::release_annotations() {
+  return std::move(m_anno);
 }
 
 void DexClass::set_deobfuscated_name(const std::string& name) {

--- a/libredex/DexClass.h
+++ b/libredex/DexClass.h
@@ -402,9 +402,7 @@ class DexField : public DexFieldRef {
 
   void set_value(DexEncodedValue* v);
 
-  std::unique_ptr<DexAnnotationSet> release_annotations() {
-    return std::move(m_anno);
-  }
+  std::unique_ptr<DexAnnotationSet> release_annotations();
   void clear_annotations();
 
   void attach_annotation_set(std::unique_ptr<DexAnnotationSet> aset);
@@ -1039,9 +1037,7 @@ class DexMethod : public DexMethodRef {
   void make_non_concrete();
 
   void become_virtual();
-  std::unique_ptr<DexAnnotationSet> release_annotations() {
-    return std::move(m_anno);
-  }
+  std::unique_ptr<DexAnnotationSet> release_annotations();
   void clear_annotations();
 
   /**


### PR DESCRIPTION
Summary: Fix {D33847489 (https://github.com/facebook/redex/commit/950ba6effee0ed7f790278339920065f894f5b27)} for GCC. Hide the `std::move` from `release_annotation`.

Differential Revision: D33881912

