### PR TITLE
relaxing visibility constraints, restoring determinism

### DIFF
--- a/opt/rebindrefs/ReBindRefs.cpp
+++ b/opt/rebindrefs/ReBindRefs.cpp
@@ -174,12 +174,12 @@ struct Rebinder {
         if (match(name, proto, cls_meth)) {
           auto curr_vis = get_visibility(cls_meth);
           auto curr_cls_vis = get_visibility(cls);
-          if (is_private(curr_vis) || is_package_private(curr_vis) ||
-              !is_public(curr_cls_vis)) {
+          if (is_private(curr_vis) || is_package_private(curr_vis)) {
             return top_impl;
           }
           bool is_external = cls->is_external() || cls_meth->is_external();
-          if (is_external && !is_public(curr_vis)) {
+          if (is_external &&
+              (!is_public(curr_vis) || !is_public(curr_cls_vis))) {
             return top_impl;
           }
           // We can only rebind PUBLIC to PUBLIC here.
@@ -270,6 +270,7 @@ struct Rebinder {
     rebinder_refs.mrefs.insert(mref, real_ref);
     mop->set_method(real_ref);
     if (cls != nullptr && !is_public(cls)) {
+      always_assert(!is_external);
       set_public(cls);
     }
   }


### PR DESCRIPTION
Summary:
There appears to be a race between `set_public` and `is_public` checks on non-external classes.
The existing `is_public(curr_cls_vis)` check seems overly conservative to me, since we are making the selected class public anyway.
So I am moving the check to under the `is_external` check.

Differential Revision: D34829002

