### PR TITLE
fix OSS build

### DIFF
--- a/libredex/PointsToSemantics.cpp
+++ b/libredex/PointsToSemantics.cpp
@@ -539,7 +539,7 @@ std::ostream& operator<<(std::ostream& o, const PointsToAction& a) {
   const PointsToOperation& op = a.operation();
   switch (op.kind) {
   case PTS_CONST_STRING: {
-    o << a.dest() << " = " << std::quoted(op.dex_string->str());
+    o << a.dest() << " = " << std::quoted(op.dex_string->str_copy());
     break;
   }
   case PTS_CONST_CLASS: {

--- a/libredex/ReflectionAnalysis.cpp
+++ b/libredex/ReflectionAnalysis.cpp
@@ -57,11 +57,11 @@ std::ostream& operator<<(std::ostream& out,
   }
   case reflection::STRING: {
     if (x.dex_string != nullptr) {
-      const auto str = x.dex_string->str();
+      auto str = x.dex_string->str();
       if (str.empty()) {
         out << "\"\"";
       } else {
-        out << std::quoted(str);
+        out << std::quoted(str_copy(str));
       }
     }
     break;


### PR DESCRIPTION
Summary: For reasons I don't undertand, std::quoted(std::string_view) is not available in our OSS build. This is getting worked around here by copying the string into a std::string.

Differential Revision: D35553083

