### PR TITLE
Fix mac build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,8 +5,9 @@ AC_PREREQ([2.69])
 AC_INIT([redex], [1.0], [not-valid-yet@fb.com])
 AM_INIT_AUTOMAKE([subdir-objects])
 # clear out default cxx flags (was "-O2 -g") so that they don't override
-# the flags defined in AM_CXXFLAGS
-: ${CXXFLAGS=""}
+# the flags defined in AM_CXXFLAGS. add "-std" to work around gtest issue
+# on macos.
+: ${CXXFLAGS="-std=gnu++17"}
 
 # Checks for programs.
 AC_PROG_CXX

--- a/libredex/DexClass.h
+++ b/libredex/DexClass.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <utility>
 
 #include "Debug.h"


### PR DESCRIPTION
There were more mac-specific build breakages that needed to be fixed.

One was a relatively simple need to explicitly include `<unordered_map>` due to mac being weird.

The other was a breakage in gtest which does not compile in macos due to an inability in `cmake` to properly set C++17. The fix was to explicitly add `CXXFLAGS="-std=gnu++17"` to force proper compilation, although it may not be a clean fix since the comments indicate that the maintainers wanted to keep `CXXFLAGS` empty.