### PR TITLE
Make exception throwing cold.

### DIFF
--- a/sparta/include/Exceptions.h
+++ b/sparta/include/Exceptions.h
@@ -9,6 +9,8 @@
 
 #include <exception>
 
+#include <boost/config.hpp>
+#include <boost/current_function.hpp>
 #include <boost/exception/all.hpp>
 
 namespace sparta {
@@ -49,9 +51,86 @@ using operation_name =
 } // namespace sparta
 
 /*
+ * Like BOOST_THROW_EXCEPTION, but makes any path reaching the throw cold.
+ *
+ * Construction of the exception itself is quite expensive, so it is hoisted
+ * into a lambda and lazily called if needed.
+ */
+#define SPARTA_THROW_EXCEPTION(E) \
+  SPARTA_THROW_EXCEPTION_IMPL(E, __FILE__, __LINE__)
+
+/*
  * An assert-like macro that throws an exception.
  */
-#define RUNTIME_CHECK(C, E)     \
-  if (!(C)) {                   \
-    BOOST_THROW_EXCEPTION((E)); \
-  }
+#define RUNTIME_CHECK(C, E)        \
+  do                               \
+    if (BOOST_UNLIKELY(!(C))) {    \
+      SPARTA_THROW_EXCEPTION((E)); \
+    }                              \
+  while (0)
+
+namespace sparta::exception_impl {
+
+template <class E>
+BOOST_NORETURN void throw_exception(const E& x,
+                                    const char* current_function,
+                                    const char* file,
+                                    int line) {
+  // Emulates BOOST_THROW_EXCEPTION directly, except with the given context.
+#if !defined(BOOST_EXCEPTION_DISABLE)
+  boost::throw_exception(boost::enable_error_info(x)
+                         << boost::throw_function(current_function)
+                         << boost::throw_file(file) << boost::throw_line(line));
+#else
+  ::boost::ignore_unused(current_function);
+  ::boost::ignore_unused(file);
+  ::boost::ignore_unused(line);
+  ::boost::throw_exception(x);
+#endif
+}
+
+} // namespace sparta::exception_impl
+
+/*
+ * Marks a function as cold; the compiler won't optimize for the calling path.
+ */
+#ifdef __GNUC__
+#define SPARTA_COLD_FUNCTION __attribute__((cold))
+#else
+#define SPARTA_COLD_FUNCTION
+#endif
+
+/*
+ * We could just mark the lambda as the cold call, but this results in a huge
+ * semantic-less symbol for the function. It is difficult to make sense of
+ * `<giant anonymous lambda name>::operator()()` while debugging/profiling.
+ * Instead, a local struct containing the line number wraps this call into a
+ * legible (and actually useful) name.
+ *
+ * Care is taken to ensure this call requires no arguments, except those used
+ * for constructing the exception (i.e., captured by the lambda). Since the
+ * reported throwing function will change as a result of this lambda, we store
+ * it ourselves as constexpr to avoid capturing. (Whether the current function
+ * is given as a macro expansion or as a magic-defined static variable is up to
+ * the compiler, hence why we can't treat it similar to __FILE__ and __LINE__).
+ *
+ * Double macro expansion is needed to concat with the line number.
+ */
+#define SPARTA_THROW_EXCEPTION_IMPL(E, File, Line) \
+  SPARTA_THROW_EXCEPTION_IMPL2(E, File, Line)
+#define SPARTA_THROW_EXCEPTION_IMPL2(E, File, Line)             \
+  do {                                                          \
+    constexpr auto& kCurrentFunction = BOOST_CURRENT_FUNCTION;  \
+    auto throw_exception_impl = [&]() BOOST_NORETURN {          \
+      ::sparta::exception_impl::throw_exception(                \
+          (E), kCurrentFunction, File, Line);                   \
+    };                                                          \
+    struct L##Line {                                            \
+      decltype(throw_exception_impl) impl;                      \
+      BOOST_NORETURN BOOST_NOINLINE SPARTA_COLD_FUNCTION void   \
+      throw_exception() {                                       \
+        impl();                                                 \
+      }                                                         \
+    };                                                          \
+    L##Line{std::move(throw_exception_impl)}.throw_exception(); \
+  } while (0)

--- a/sparta/include/PatriciaTreeCore.h
+++ b/sparta/include/PatriciaTreeCore.h
@@ -1055,8 +1055,8 @@ inline intrusive_ptr<PatriciaTreeLeaf<IntegerType, Value>> use_available_leaf(
   } else if (y) {
     return y;
   } else {
-    BOOST_THROW_EXCEPTION(internal_error()
-                          << error_msg("Malformed Patricia tree"));
+    SPARTA_THROW_EXCEPTION(internal_error()
+                           << error_msg("Malformed Patricia tree"));
   }
 }
 

--- a/sparta/include/S_Expression.h
+++ b/sparta/include/S_Expression.h
@@ -526,12 +526,10 @@ class List final : public Component {
   size_t size() const { return m_list.size(); }
 
   s_expr get_element(size_t index) const {
-    try {
-      return m_list.at(index);
-    } catch (const std::out_of_range& e) {
-      // The `at` function throws an exception if the index doesn't lie within
-      // the bounds of the vector.
-      BOOST_THROW_EXCEPTION(invalid_argument() << argument_name("index"));
+    if (index < m_list.size()) {
+      return m_list[index];
+    } else {
+      SPARTA_THROW_EXCEPTION(invalid_argument() << argument_name("index"));
     }
   }
 


### PR DESCRIPTION
Summary:
`BOOST_THROW_EXCEPTION` (and by extension `RUNTIME_CHECK`) expands to a significant amount of code, responsible for allocating, copying, and destroying exception vtables and strings. This prevents even tiny functions from inlining since the callee stack space is desirable for optimizing this process.

We expect to never throw. This diff hoists the act of constructing and throwing an exception behind a cold noinline function - this minimizes pollution of the calling site and allows these functions to freely inline.

Differential Revision: D37623344

