### PR TITLE
Use clz directly for join.

### DIFF
--- a/libredex/NullnessDomain.h
+++ b/libredex/NullnessDomain.h
@@ -23,7 +23,8 @@ enum Nullness {
   NN_TOP // Nullable
 };
 
-using NullnessLattice = sparta::BitVectorLattice<Nullness, 5, std::hash<int>>;
+using NullnessLattice = sparta::BitVectorLattice<Nullness,
+                                                 /* kCardinality */ 5>;
 
 /*
  *         TOP (Nullable)

--- a/libredex/TypeInference.h
+++ b/libredex/TypeInference.h
@@ -124,7 +124,8 @@ namespace type_inference {
 
 using std::placeholders::_1;
 
-using TypeLattice = sparta::BitVectorLattice<IRType, 16, std::hash<int>>;
+using TypeLattice = sparta::BitVectorLattice<IRType,
+                                             /* kCardinality */ 16>;
 
 extern TypeLattice type_lattice;
 

--- a/service/constant-propagation/ObjectDomain.h
+++ b/service/constant-propagation/ObjectDomain.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include <boost/functional/hash.hpp>
-
 #include "DexClass.h"
 #include "FiniteAbstractDomain.h"
 #include "PatriciaTreeMapAbstractEnvironment.h"
@@ -33,8 +31,7 @@ enum class EscapeState {
 namespace escape_domain_impl {
 
 using Lattice = sparta::BitVectorLattice<EscapeState,
-                                         /* cardinality */ 4,
-                                         boost::hash<EscapeState>>;
+                                         /* kCardinality */ 4>;
 
 extern Lattice lattice;
 

--- a/service/constant-propagation/SignDomain.cpp
+++ b/service/constant-propagation/SignDomain.cpp
@@ -7,6 +7,8 @@
 
 #include "SignDomain.h"
 
+#include <limits>
+
 #include "Debug.h"
 
 namespace sign_domain {

--- a/service/constant-propagation/SignDomain.h
+++ b/service/constant-propagation/SignDomain.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include <boost/functional/hash.hpp>
-
 #include "FiniteAbstractDomain.h"
 
 /*
@@ -30,9 +28,8 @@ enum class Interval {
   SIZE // The number of items in Interval
 };
 
-using Lattice = sparta::BitVectorLattice<Interval,
-                                         static_cast<size_t>(Interval::SIZE),
-                                         boost::hash<Interval>>;
+using Lattice =
+    sparta::BitVectorLattice<Interval, static_cast<size_t>(Interval::SIZE)>;
 
 extern Lattice lattice;
 

--- a/service/regalloc/RegisterType.h
+++ b/service/regalloc/RegisterType.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include <boost/functional/hash.hpp>
-
 #include "FiniteAbstractDomain.h"
 #include "IRInstruction.h"
 
@@ -45,8 +43,7 @@ namespace register_type_impl {
 
 using Lattice =
     sparta::BitVectorLattice<RegisterType,
-                             static_cast<size_t>(RegisterType::SIZE),
-                             boost::hash<RegisterType>>;
+                             static_cast<size_t>(RegisterType::SIZE)>;
 
 extern Lattice lattice;
 

--- a/sparta/include/FiniteAbstractDomain.h
+++ b/sparta/include/FiniteAbstractDomain.h
@@ -16,14 +16,16 @@
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "AbstractDomain.h"
+#include "Exceptions.h"
 
 namespace sparta {
 
 namespace fad_impl {
 
-template <typename Element, size_t cardinality, typename Hash, typename Equal>
+template <typename Element, size_t kCardinality>
 class BitVectorSemiLattice;
 
 } // namespace fad_impl
@@ -71,7 +73,7 @@ class LatticeEncoding {
  *             BOTTOM
  *
  *   enum Elements {BOTTOM, A, B, TOP};
- *   using Lattice = BitVectorLattice<Elements, 4, std::hash<int>>;
+ *   using Lattice = BitVectorLattice<Elements, 4>;
  *   Lattice lattice({BOTTOM, A, B, TOP},
  *                   {{BOTTOM, A}, {BOTTOM, B}, {A, TOP}, {B, TOP}});
  *   using Domain =
@@ -181,31 +183,20 @@ namespace sparta {
  * This maintains two semi-lattices internally; always use the opposite
  * semi-lattice representation and calculate corresponding lower semi-lattice
  * encoding when needed.
+ *
+ * The last two template parameters are unused and will be eventually removed.
  */
 template <typename Element,
-          size_t cardinality,
-          typename Hash = std::hash<Element>,
-          typename Equal = std::equal_to<Element>>
+          size_t kCardinality,
+          typename = void,
+          typename = void>
 class BitVectorLattice final
-    : public fad_impl::BitVectorSemiLattice<Element, cardinality, Hash, Equal>::
-          LatticeEncoding {
-  using SemiLattice =
-      fad_impl::BitVectorSemiLattice<Element, cardinality, Hash, Equal>;
+    : public fad_impl::BitVectorSemiLattice<Element,
+                                            kCardinality>::LatticeEncoding {
+  using SemiLattice = fad_impl::BitVectorSemiLattice<Element, kCardinality>;
 
  public:
   using Encoding = typename SemiLattice::Encoding;
-
-  ~BitVectorLattice() {
-    // The destructor is the only method that is guaranteed to be created when a
-    // class template is instantiated. This is a good place to perform all the
-    // sanity checks on the template parameters.
-    static_assert(std::is_default_constructible<Element>::value,
-                  "Element is not default constructible");
-    static_assert(std::is_copy_constructible<Element>::value,
-                  "Element is not copy constructible");
-    static_assert(std::is_copy_assignable<Element>::value,
-                  "Element is not copy assignable");
-  }
 
   /*
    * In a standard fixpoint computation the Join is by far the dominant
@@ -290,6 +281,35 @@ class BitVectorLattice final
 
 namespace fad_impl {
 
+template <typename Element, typename ElementAsInt = Element>
+bool is_zero_based_integer_range(
+    const std::initializer_list<Element>& elements) {
+  if constexpr (std::is_integral_v<ElementAsInt>) {
+    std::vector<bool> seen(elements.size());
+    for (const auto element : elements) {
+      const auto element_int = static_cast<ElementAsInt>(element);
+      if (element_int >= 0) {
+        const auto element_index = static_cast<size_t>(element_int);
+        if (element_index < seen.size() && !seen[element_index]) {
+          seen[element_index] = true;
+          continue;
+        }
+      }
+
+      // Negative, beyond cardinality, or duplicated.
+      return false;
+    }
+
+    // We saw K unique elements in the range [0, K).
+    return true;
+  } else if constexpr (std::is_enum_v<ElementAsInt>) {
+    using Underlying = std::underlying_type_t<Element>;
+    return is_zero_based_integer_range<Element, Underlying>(elements);
+  } else {
+    return false;
+  }
+}
+
 /*
  * Our encoding of lattices is based on the following paper that proposes an
  * efficient representation based on bit vectors:
@@ -354,12 +374,12 @@ namespace fad_impl {
  * should not be a problem in practice.
  *
  */
-template <typename Element, size_t cardinality, typename Hash, typename Equal>
+template <typename Element, size_t kCardinality>
 class BitVectorSemiLattice final {
  public:
-  // The size of a bitset structure is a compile-time constant, hence the need
-  // for the 'cardinality' parameter.
-  using Encoding = std::bitset<cardinality>;
+  static_assert(kCardinality >= 2, "Lattice must have at least 2 elements.");
+
+  using Encoding = std::bitset<kCardinality>;
 
   // The lattice encoding we're used to implement.
   using LatticeEncoding = ::sparta::LatticeEncoding<Element, Encoding>;
@@ -375,24 +395,31 @@ class BitVectorSemiLattice final {
       std::initializer_list<Element> elements,
       std::initializer_list<std::pair<Element, Element>> hasse_diagram,
       bool construct_opposite_lattice) {
-    RUNTIME_CHECK(elements.size() == cardinality,
+    // For efficiency we will require elements be integer-like and in a
+    // continuous range [0, K). We could relax this in various ways and have
+    // fallback cases, but every current usage satisfies this restriction.
+    RUNTIME_CHECK(elements.size() == kCardinality,
+                  invalid_argument()
+                      << argument_name("elements")
+                      << operation_name("BitVectorSemiLattice()"));
+    RUNTIME_CHECK(is_zero_based_integer_range(elements),
                   invalid_argument()
                       << argument_name("elements")
                       << operation_name("BitVectorSemiLattice()"));
 
     // We assign each element of the lattice an index, so that we can construct
     // the Boolean matrix.
-    Element index_to_element[cardinality];
-    std::unordered_map<Element, size_t, Hash, Equal> element_to_index;
+    Element index_to_element[kCardinality];
+    std::unordered_map<Element, size_t> element_to_index;
 
     std::copy(elements.begin(), elements.end(), index_to_element);
-    for (size_t i = 0; i < cardinality; ++i) {
+    for (size_t i = 0; i < kCardinality; ++i) {
       element_to_index[index_to_element[i]] = i;
     }
 
     // We populate the Boolean matrix by traversing the Hasse diagram of the
     // partial order.
-    Encoding matrix[cardinality];
+    Encoding matrix[kCardinality];
     for (auto pair : hasse_diagram) {
       // The Hasse diagram provided by the user describes the partial order in
       // the original lattice. We need to normalize the representation when the
@@ -413,15 +440,15 @@ class BitVectorSemiLattice final {
 
     // We first compute the reflexive closure of the "immediately greater than"
     // relation in the lattice considered.
-    for (size_t i = 0; i < cardinality; ++i) {
+    for (size_t i = 0; i < kCardinality; ++i) {
       matrix[i][i] = true;
     }
 
     // Then we compute the transitive closure of the "immediately greater than"
     // relation in the lattice considered, using Warshall's algorithm.
-    for (size_t k = 0; k < cardinality; ++k) {
-      for (size_t i = 0; i < cardinality; ++i) {
-        for (size_t j = 0; j < cardinality; ++j) {
+    for (size_t k = 0; k < kCardinality; ++k) {
+      for (size_t i = 0; i < kCardinality; ++i) {
+        for (size_t j = 0; j < kCardinality; ++j) {
           matrix[i][j] = matrix[i][j] || (matrix[i][k] && matrix[k][j]);
         }
       }
@@ -430,7 +457,7 @@ class BitVectorSemiLattice final {
     // The last step is to assign a bit vector representation to each element in
     // the lattice considered, i.e. the corresponding row in the Boolean matrix.
     // We also maintain a reverse table for decoding purposes.
-    for (size_t i = 0; i < cardinality; ++i) {
+    for (size_t i = 0; i < kCardinality; ++i) {
       Element element = index_to_element[i];
       Encoding encoding = matrix[i];
       m_element_to_encoding[element] = encoding;
@@ -495,7 +522,7 @@ class BitVectorSemiLattice final {
     size_t all_bits_are_set = 0;
     // We count the number of bit vectors that have only one bit set to one.
     size_t one_bit_is_set = 0;
-    for (size_t i = 0; i < cardinality; ++i) {
+    for (size_t i = 0; i < kCardinality; ++i) {
       Encoding x = m_element_to_encoding[index_to_element[i]];
       if (x.all()) {
         ++all_bits_are_set;
@@ -503,7 +530,7 @@ class BitVectorSemiLattice final {
       if (x.count() == 1) {
         ++one_bit_is_set;
       }
-      for (size_t j = 0; j < cardinality; ++j) {
+      for (size_t j = 0; j < kCardinality; ++j) {
         Encoding y = m_element_to_encoding[index_to_element[j]];
         RUNTIME_CHECK(m_encoding_to_element.find(x & y) !=
                           m_encoding_to_element.end(),
@@ -515,7 +542,7 @@ class BitVectorSemiLattice final {
                       << error_msg("Missing or duplicate extremal element"));
   }
 
-  std::unordered_map<Element, Encoding, Hash, Equal> m_element_to_encoding;
+  std::unordered_map<Element, Encoding> m_element_to_encoding;
   std::unordered_map<Encoding, Element> m_encoding_to_element;
   Encoding m_bottom;
   Encoding m_top;

--- a/sparta/test/DirectProductAbstractDomainTest.cpp
+++ b/sparta/test/DirectProductAbstractDomainTest.cpp
@@ -21,9 +21,9 @@ enum Elements0 { BOT0, TOP0 };
 enum Elements1 { BOT1, A, B, TOP1 };
 enum Elements2 { BOT2, C, D, E, F, TOP2 };
 
-using Lattice0 = BitVectorLattice<Elements0, 2, std::hash<int>>;
-using Lattice1 = BitVectorLattice<Elements1, 4, std::hash<int>>;
-using Lattice2 = BitVectorLattice<Elements2, 6, std::hash<int>>;
+using Lattice0 = BitVectorLattice<Elements0, /* kCardinality */ 2>;
+using Lattice1 = BitVectorLattice<Elements1, /* kCardinality */ 4>;
+using Lattice2 = BitVectorLattice<Elements2, /* kCardinality */ 6>;
 
 /*
  *         TOP0
@@ -77,8 +77,8 @@ INSTANTIATE_TYPED_TEST_CASE_P(DirectProductAbstractDomain,
 template <>
 std::vector<D0xD1xD2>
 AbstractDomainPropertyTest<D0xD1xD2>::non_extremal_values() {
-  D0xD1xD2 tad(make_tuple(D0(TOP0), D1(A), D2(D)));
-  D0xD1xD2 tbe(make_tuple(D0(TOP0), D1(B), D2(E)));
+  D0xD1xD2 tad(std::make_tuple(D0(TOP0), D1(A), D2(D)));
+  D0xD1xD2 tbe(std::make_tuple(D0(TOP0), D1(B), D2(E)));
   return {tad, tbe};
 }
 
@@ -99,8 +99,8 @@ TEST(DirectProductAbstractDomainTest, latticeOperations) {
     EXPECT_EQ(expected.str(), out.str());
   }
 
-  D0xD1xD2 tad(make_tuple(D0(TOP0), D1(A), D2(D)));
-  D0xD1xD2 tbe(make_tuple(D0(TOP0), D1(B), D2(E)));
+  D0xD1xD2 tad(std::make_tuple(D0(TOP0), D1(A), D2(D)));
+  D0xD1xD2 tbe(std::make_tuple(D0(TOP0), D1(B), D2(E)));
   D0xD1xD2 join = tad.join(tbe);
   EXPECT_TRUE(join.get<0>().is_top());
   EXPECT_TRUE(join.get<1>().is_top());
@@ -113,14 +113,14 @@ TEST(DirectProductAbstractDomainTest, latticeOperations) {
   EXPECT_TRUE(bottom_meet.get<1>().is_bottom());
   EXPECT_EQ(bottom_meet.get<2>().element(), C);
 
-  D0xD1xD2 tte(make_tuple(D0(TOP0), D1(TOP1), D2(E)));
+  D0xD1xD2 tte(std::make_tuple(D0(TOP0), D1(TOP1), D2(E)));
   D0xD1xD2 meet = tad.meet(tte);
   EXPECT_TRUE(meet.get<0>().is_top());
   EXPECT_EQ(A, meet.get<1>().element());
   EXPECT_EQ(C, meet.get<2>().element());
   EXPECT_TRUE(meet.equals(tad.narrowing(tte)));
 
-  D0xD1xD2 bad(make_tuple(D0(BOT0), D1(A), D2(D)));
+  D0xD1xD2 bad(std::make_tuple(D0(BOT0), D1(A), D2(D)));
   EXPECT_FALSE(bad.is_bottom());
   EXPECT_TRUE(bad.get<0>().is_bottom());
   EXPECT_EQ(bad.get<1>().element(), A);
@@ -128,9 +128,9 @@ TEST(DirectProductAbstractDomainTest, latticeOperations) {
 }
 
 TEST(DirectProductAbstractDomainTest, destructiveOperations) {
-  D0xD1xD2 tad(make_tuple(D0(TOP0), D1(A), D2(D)));
-  D0xD1xD2 tbe(make_tuple(D0(TOP0), D1(B), D2(E)));
-  D0xD1xD2 ttf(make_tuple(D0(TOP0), D1(TOP1), D2(F)));
+  D0xD1xD2 tad(std::make_tuple(D0(TOP0), D1(A), D2(D)));
+  D0xD1xD2 tbe(std::make_tuple(D0(TOP0), D1(B), D2(E)));
+  D0xD1xD2 ttf(std::make_tuple(D0(TOP0), D1(TOP1), D2(F)));
   D0xD1xD2 x = tad;
   D0xD1xD2 tbe1 = tbe;
   x.join_with(tbe);
@@ -170,7 +170,7 @@ TEST(DirectProductAbstractDomainTest, destructiveOperations) {
   x.set_to_top();
   EXPECT_TRUE(x.is_top());
 
-  D0xD1xD2 tae(make_tuple(D0(TOP0), D1(A), D2(E)));
+  D0xD1xD2 tae(std::make_tuple(D0(TOP0), D1(A), D2(E)));
   D0xD1xD2 tac = tad.meet(tae);
   EXPECT_TRUE(tac.get<0>().is_top());
   EXPECT_EQ(A, tac.get<1>().element());

--- a/sparta/test/InterproceduralAnalyzerTest.cpp
+++ b/sparta/test/InterproceduralAnalyzerTest.cpp
@@ -379,7 +379,7 @@ struct Summary : public sparta::AbstractDomain<Summary> {
 };
 
 enum Elements { BOTTOM, PURE, IMPURE, TOP };
-using Lattice = sparta::BitVectorLattice<Elements, 4, std::hash<int>>;
+using Lattice = sparta::BitVectorLattice<Elements, /* kCardinality */ 4>;
 Lattice lattice({BOTTOM, PURE, IMPURE, TOP},
                 {{BOTTOM, PURE}, {BOTTOM, IMPURE}, {PURE, TOP}, {IMPURE, TOP}});
 

--- a/sparta/test/ReducedProductAbstractDomainTest.cpp
+++ b/sparta/test/ReducedProductAbstractDomainTest.cpp
@@ -21,9 +21,9 @@ enum Elements0 { BOT0, TOP0 };
 enum Elements1 { BOT1, A, B, TOP1 };
 enum Elements2 { BOT2, C, D, E, F, TOP2 };
 
-using Lattice0 = BitVectorLattice<Elements0, 2, std::hash<int>>;
-using Lattice1 = BitVectorLattice<Elements1, 4, std::hash<int>>;
-using Lattice2 = BitVectorLattice<Elements2, 6, std::hash<int>>;
+using Lattice0 = BitVectorLattice<Elements0, /* kCardinality */ 2>;
+using Lattice1 = BitVectorLattice<Elements1, /* kCardinality */ 4>;
+using Lattice2 = BitVectorLattice<Elements2, /* kCardinality */ 6>;
 
 /*
  *         TOP0
@@ -85,8 +85,8 @@ INSTANTIATE_TYPED_TEST_CASE_P(ReducedProductAbstractDomain,
 template <>
 std::vector<D0xD1xD2>
 AbstractDomainPropertyTest<D0xD1xD2>::non_extremal_values() {
-  D0xD1xD2 tad(make_tuple(D0(TOP0), D1(A), D2(D)));
-  D0xD1xD2 tbe(make_tuple(D0(TOP0), D1(B), D2(E)));
+  D0xD1xD2 tad(std::make_tuple(D0(TOP0), D1(A), D2(D)));
+  D0xD1xD2 tbe(std::make_tuple(D0(TOP0), D1(B), D2(E)));
   return {tad, tbe};
 }
 
@@ -107,8 +107,8 @@ TEST(ReducedProductAbstractDomainTest, latticeOperations) {
     EXPECT_EQ(expected.str(), out.str());
   }
 
-  D0xD1xD2 tad(make_tuple(D0(TOP0), D1(A), D2(D)));
-  D0xD1xD2 tbe(make_tuple(D0(TOP0), D1(B), D2(E)));
+  D0xD1xD2 tad(std::make_tuple(D0(TOP0), D1(A), D2(D)));
+  D0xD1xD2 tbe(std::make_tuple(D0(TOP0), D1(B), D2(E)));
   D0xD1xD2 join = tad.join(tbe);
   EXPECT_TRUE(join.get<0>().is_top());
   EXPECT_TRUE(join.get<1>().is_top());
@@ -121,20 +121,20 @@ TEST(ReducedProductAbstractDomainTest, latticeOperations) {
   EXPECT_TRUE(bottom_meet.get<1>().is_bottom());
   EXPECT_TRUE(bottom_meet.get<2>().is_bottom());
 
-  D0xD1xD2 tte(make_tuple(D0(TOP0), D1(TOP1), D2(E)));
+  D0xD1xD2 tte(std::make_tuple(D0(TOP0), D1(TOP1), D2(E)));
   D0xD1xD2 meet = tad.meet(tte);
   EXPECT_TRUE(meet.get<0>().is_top());
   EXPECT_EQ(A, meet.get<1>().element());
   EXPECT_EQ(C, meet.get<2>().element());
   EXPECT_TRUE(meet.equals(tad.narrowing(tte)));
 
-  D0xD1xD2 bad(make_tuple(D0(BOT0), D1(A), D2(D)));
+  D0xD1xD2 bad(std::make_tuple(D0(BOT0), D1(A), D2(D)));
   EXPECT_TRUE(bad.is_bottom());
   EXPECT_TRUE(bad.get<0>().is_bottom());
   EXPECT_TRUE(bad.get<1>().is_bottom());
   EXPECT_TRUE(bad.get<2>().is_bottom());
 
-  D0xD1xD2 tac_reduced(make_tuple(D0(BOT0), D1(A), D2(C)));
+  D0xD1xD2 tac_reduced(std::make_tuple(D0(BOT0), D1(A), D2(C)));
   EXPECT_TRUE(tac_reduced.is_bottom());
 }
 
@@ -158,9 +158,9 @@ TEST(ReducedProductAbstractDomainTest, normalizedConstruction) {
 }
 
 TEST(ReducedProductAbstractDomainTest, destructiveOperations) {
-  D0xD1xD2 tad(make_tuple(D0(TOP0), D1(A), D2(D)));
-  D0xD1xD2 tbe(make_tuple(D0(TOP0), D1(B), D2(E)));
-  D0xD1xD2 ttf(make_tuple(D0(TOP0), D1(TOP1), D2(F)));
+  D0xD1xD2 tad(std::make_tuple(D0(TOP0), D1(A), D2(D)));
+  D0xD1xD2 tbe(std::make_tuple(D0(TOP0), D1(B), D2(E)));
+  D0xD1xD2 ttf(std::make_tuple(D0(TOP0), D1(TOP1), D2(F)));
   D0xD1xD2 x = tad;
   D0xD1xD2 tbe1 = tbe;
   x.join_with(tbe);
@@ -200,7 +200,7 @@ TEST(ReducedProductAbstractDomainTest, destructiveOperations) {
   x.set_to_top();
   EXPECT_TRUE(x.is_top());
 
-  D0xD1xD2 tae(make_tuple(D0(TOP0), D1(A), D2(E)));
+  D0xD1xD2 tae(std::make_tuple(D0(TOP0), D1(A), D2(E)));
   D0xD1xD2 tac = tad.meet(tae);
   EXPECT_TRUE(tac.get<0>().is_top());
   EXPECT_EQ(A, tac.get<1>().element());


### PR DESCRIPTION
Summary: The clz of an encoding provides an element identity, in a relabelled space. This is sufficient for indexing; we don't need to decode all the way to an element just to join encodings.

Differential Revision: D37775178

