### PR TITLE
Outline node deletion.

### DIFF
--- a/libredex/CFGMutation.cpp
+++ b/libredex/CFGMutation.cpp
@@ -192,8 +192,6 @@ void CFGMutation::flush() {
   m_changes.clear();
 }
 
-CFGMutation::ChangeSet::~ChangeSet() {}
-
 bool CFGMutation::ChangeSet::apply(ControlFlowGraph& cfg,
                                    cfg::Block* block,
                                    ir_list::InstructionIterator& it) {

--- a/libredex/CFGMutation.h
+++ b/libredex/CFGMutation.h
@@ -186,7 +186,6 @@ class CFGMutation {
   class ChangeSet {
    public:
     explicit ChangeSet(const IRList::iterator& it) : m_it(it) {}
-    ~ChangeSet();
 
     enum class Insert { Before, After, Replacing };
     /// Apply this change on the control flow graph \p cfg, using \p it as the

--- a/libredex/MatchFlowDetail.cpp
+++ b/libredex/MatchFlowDetail.cpp
@@ -172,8 +172,6 @@ struct InconsistentDFGNodesAnalysis
 
 } // namespace
 
-InstructionMatcher::~InstructionMatcher() = default;
-
 const Constraint::Src& Constraint::src(src_index_t ix) const {
   if (ix < m_srcs.size()) {
     if (auto& src = m_srcs[ix]; src.loc != NO_LOC) {

--- a/libredex/MatchFlowDetail.h
+++ b/libredex/MatchFlowDetail.h
@@ -57,7 +57,7 @@ enum class QuantFlag : uint16_t {
  * in-memory representation is hidden by a memory indirection.
  */
 struct InstructionMatcher {
-  virtual ~InstructionMatcher() = 0;
+  virtual ~InstructionMatcher() = default;
   virtual bool matches(const IRInstruction* insn) const = 0;
 };
 

--- a/service/constant-propagation/ConstantArrayDomain.h
+++ b/service/constant-propagation/ConstantArrayDomain.h
@@ -48,6 +48,9 @@ class ConstantArrayDomain final
                                            ArrayValuesDomain>;
   using typename SuperType::ReducedProductAbstractDomain;
 
+  static_assert(std::is_same_v<decltype(Domain::default_value()), Domain>,
+                "Domain::default_value() does not exist");
+
   // Some older compilers complain that the class is not default constructible.
   // We intended to use the default constructors of the base class (via the
   // `using` declaration above), but some compilers fail to catch this. So we
@@ -56,15 +59,6 @@ class ConstantArrayDomain final
 
   static void reduce_product(
       std::tuple<ArrayLengthDomain, ArrayValuesDomain>& domains) {}
-
-  ~ConstantArrayDomain() override {
-    // The destructor is the only method that is guaranteed to be created when
-    // a class template is instantiated. This is a good place to perform all
-    // the sanity checks on the template parameters.
-    static_assert(
-        std::is_same<decltype(Domain::default_value()), Domain>::value,
-        "Domain::default_value() does not exist");
-  }
 
   explicit ConstantArrayDomain(uint32_t length) {
     mutate_array_length(

--- a/sparta/include/AbstractDomain.h
+++ b/sparta/include/AbstractDomain.h
@@ -16,6 +16,10 @@
 #include "Exceptions.h"
 
 namespace sparta {
+namespace ad_impl {
+template <typename Value, typename Derived>
+class AbstractDomainScaffoldingStaticAssert;
+} // namespace ad_impl
 
 /*
  * This is an API for abstract domains, which are the fundamental structures in
@@ -337,16 +341,10 @@ using actual_kind =
  *
  */
 template <typename Value, typename Derived>
-class AbstractDomainScaffolding : public AbstractDomain<Derived> {
+class AbstractDomainScaffolding
+    : public AbstractDomain<Derived>,
+      private ad_impl::AbstractDomainScaffoldingStaticAssert<Value, Derived> {
  public:
-  virtual ~AbstractDomainScaffolding() {
-    static_assert(std::is_base_of<AbstractValue<Value>, Value>::value,
-                  "Value doesn't inherit from AbstractValue");
-    static_assert(std::is_base_of<AbstractDomainScaffolding<Value, Derived>,
-                                  Derived>::value,
-                  "Derived doesn't inherit from AbstractDomainScaffolding");
-  }
-
   /*
    * The choice of lattice element returned by the default constructor is
    * completely arbitrary. In pratice though, the abstract value used to
@@ -653,3 +651,19 @@ inline std::ostream& operator<<(
   o << d.unwrap();
   return o;
 }
+
+namespace sparta::ad_impl {
+
+template <typename Value, typename Derived>
+class AbstractDomainScaffoldingStaticAssert {
+ protected:
+  ~AbstractDomainScaffoldingStaticAssert() {
+    static_assert(std::is_base_of_v<AbstractValue<Value>, Value>,
+                  "Value doesn't inherit from AbstractValue");
+    static_assert(
+        std::is_base_of_v<AbstractDomainScaffolding<Value, Derived>, Derived>,
+        "Derived doesn't inherit from AbstractDomainScaffolding");
+  }
+};
+
+} // namespace sparta::ad_impl

--- a/sparta/include/AbstractDomain.h
+++ b/sparta/include/AbstractDomain.h
@@ -455,9 +455,9 @@ class AbstractDomainScaffolding
 
   const Value* get_value() const { return &m_value; }
 
-  void set_to_value(const Value& value) {
+  void set_to_value(Value value) {
     m_kind = value.kind();
-    m_value = value;
+    m_value = std::move(value);
   }
 
   // In some implementations, the data structure chosen to represent an abstract

--- a/sparta/include/ConstantAbstractDomain.h
+++ b/sparta/include/ConstantAbstractDomain.h
@@ -56,8 +56,8 @@ class ConstantAbstractValue final
 
   ConstantAbstractValue() = default;
 
-  explicit ConstantAbstractValue(const Constant& constant)
-      : m_constant(constant) {}
+  explicit ConstantAbstractValue(Constant constant)
+      : m_constant(std::move(constant)) {}
 
   void clear() override {}
 

--- a/sparta/include/ConstantAbstractDomain.h
+++ b/sparta/include/ConstantAbstractDomain.h
@@ -47,14 +47,12 @@ template <typename Constant>
 class ConstantAbstractValue final
     : public AbstractValue<ConstantAbstractValue<Constant>> {
  public:
-  ~ConstantAbstractValue() {
-    static_assert(std::is_default_constructible<Constant>::value,
-                  "Constant is not default constructible");
-    static_assert(std::is_copy_constructible<Constant>::value,
-                  "Constant is not copy constructible");
-    static_assert(std::is_copy_assignable<Constant>::value,
-                  "Constant is not copy assignable");
-  }
+  static_assert(std::is_default_constructible_v<Constant>,
+                "Constant is not default constructible");
+  static_assert(std::is_copy_constructible_v<Constant>,
+                "Constant is not copy constructible");
+  static_assert(std::is_copy_assignable_v<Constant>,
+                "Constant is not copy assignable");
 
   ConstantAbstractValue() = default;
 
@@ -131,14 +129,12 @@ class ConstantAbstractValueRepr<
   Constant m_constant;
 
  public:
-  ~ConstantAbstractValueRepr() {
-    static_assert(static_cast<size_t>(AbstractValueKind::Bottom) < 4,
-                  "AbstractValueKind doesn't fit into 2 bits");
-    static_assert(static_cast<size_t>(AbstractValueKind::Value) < 4,
-                  "AbstractValueKind doesn't fit into 2 bits");
-    static_assert(static_cast<size_t>(AbstractValueKind::Top) < 4,
-                  "AbstractValueKind doesn't fit into 2 bits");
-  }
+  static_assert(static_cast<size_t>(AbstractValueKind::Bottom) < 4,
+                "AbstractValueKind doesn't fit into 2 bits");
+  static_assert(static_cast<size_t>(AbstractValueKind::Value) < 4,
+                "AbstractValueKind doesn't fit into 2 bits");
+  static_assert(static_cast<size_t>(AbstractValueKind::Top) < 4,
+                "AbstractValueKind doesn't fit into 2 bits");
 
   AbstractValueKind kind() const {
     return static_cast<AbstractValueKind>(
@@ -165,8 +161,6 @@ class ConstantAbstractDomain final
  public:
   using ReprType = acd_impl::ConstantAbstractValueRepr<Constant>;
   using ConstantType = Constant;
-
-  virtual ~ConstantAbstractDomain() {}
 
   ConstantAbstractDomain() { m_repr.set(AbstractValueKind::Top); }
 

--- a/sparta/include/DirectProductAbstractDomain.h
+++ b/sparta/include/DirectProductAbstractDomain.h
@@ -43,14 +43,8 @@ namespace sparta {
 template <typename Derived, typename... Domains>
 class DirectProductAbstractDomain : public AbstractDomain<Derived> {
  public:
-  ~DirectProductAbstractDomain() {
-    // The destructor is the only method that is guaranteed to be created when a
-    // class template is instantiated. This is a good place to perform all the
-    // sanity checks on the template parameters.
-    static_assert(
-        sizeof...(Domains) >= 2,
-        "DirectProductAbstractDomain requires at least two parameters");
-  }
+  static_assert(sizeof...(Domains) >= 2,
+                "DirectProductAbstractDomain requires at least two parameters");
 
   /*
    * Defining a public variadic constructor will invariably lead to instances of

--- a/sparta/include/DisjointUnionAbstractDomain.h
+++ b/sparta/include/DisjointUnionAbstractDomain.h
@@ -64,7 +64,8 @@ class DisjointUnionAbstractDomain final
   DisjointUnionAbstractDomain() : m_variant(FirstDomain::top()) {}
 
   template <typename Domain>
-  /* implicit */ DisjointUnionAbstractDomain(Domain d) : m_variant(d) {}
+  /* implicit */ DisjointUnionAbstractDomain(Domain d)
+      : m_variant(std::move(d)) {}
 
   static DisjointUnionAbstractDomain top() {
     return DisjointUnionAbstractDomain(FirstDomain::top());

--- a/sparta/include/FiniteAbstractDomain.h
+++ b/sparta/include/FiniteAbstractDomain.h
@@ -104,14 +104,8 @@ class FiniteAbstractDomain final
     : public AbstractDomain<
           FiniteAbstractDomain<Element, Lattice, Encoding, lattice>> {
  public:
-  ~FiniteAbstractDomain() {
-    // The destructor is the only method that is guaranteed to be created when a
-    // class template is instantiated. This is a good place to perform all the
-    // sanity checks on the template parameters.
-    static_assert(
-        std::is_base_of<LatticeEncoding<Element, Encoding>, Lattice>::value,
-        "Lattice doesn't derive from LatticeEncoding");
-  }
+  static_assert(std::is_base_of_v<LatticeEncoding<Element, Encoding>, Lattice>,
+                "Lattice doesn't derive from LatticeEncoding");
 
   /*
    * A default constructor is required in the AbstractDomain specification.

--- a/sparta/include/HashedAbstractPartition.h
+++ b/sparta/include/HashedAbstractPartition.h
@@ -93,15 +93,14 @@ class HashedAbstractPartition final
    * This is a no-op if the partition is set to Top.
    */
   HashedAbstractPartition& set(const Label& label, const Domain& value) {
-    if (is_top()) {
-      return *this;
-    }
-    if (value.is_bottom()) {
-      m_map.erase(label);
-    } else {
-      m_map[label] = value;
-    }
-    return *this;
+    return set_internal(label, value);
+  }
+
+  /*
+   * This is a no-op if the partition is set to Top.
+   */
+  HashedAbstractPartition& set(const Label& label, Domain&& value) {
+    return set_internal(label, std::move(value));
   }
 
   /*
@@ -272,6 +271,19 @@ class HashedAbstractPartition final
   }
 
  private:
+  template <typename D>
+  HashedAbstractPartition& set_internal(const Label& label, D&& value) {
+    if (is_top()) {
+      return *this;
+    }
+    if (value.is_bottom()) {
+      m_map.erase(label);
+    } else {
+      m_map.insert_or_assign(label, std::forward<D>(value));
+    }
+    return *this;
+  }
+
   std::unordered_map<Label, Domain, LabelHash, LabelEqual> m_map;
   bool m_is_top{false};
 };

--- a/sparta/include/HashedSetAbstractDomain.h
+++ b/sparta/include/HashedSetAbstractDomain.h
@@ -35,7 +35,7 @@ class SetValue final : public PowersetImplementation<
 
   SetValue() = default;
 
-  SetValue(const Element& e) { set().insert(e); }
+  SetValue(Element e) { add(std::move(e)); }
 
   SetValue(std::initializer_list<Element> l) {
     if (l.begin() != l.end()) {
@@ -74,7 +74,9 @@ class SetValue final : public PowersetImplementation<
     return m_set && m_set->count(e) > 0;
   }
 
-  void add(const Element& e) override { set().insert(e); }
+  void add(const Element& e) override { set().emplace(e); }
+
+  void add(Element&& e) override { set().emplace(std::move(e)); }
 
   void remove(const Element& e) override {
     if (m_set) {
@@ -199,8 +201,8 @@ class HashedSetAbstractDomain final
                                const std::unordered_set<Element, Hash, Equal>&,
                                HashedSetAbstractDomain>(kind) {}
 
-  explicit HashedSetAbstractDomain(const Element& e) {
-    this->set_to_value(Value(e));
+  explicit HashedSetAbstractDomain(Element e) {
+    this->set_to_value(Value(std::move(e)));
   }
 
   explicit HashedSetAbstractDomain(std::initializer_list<Element> l) {

--- a/sparta/include/PatriciaTreeCore.h
+++ b/sparta/include/PatriciaTreeCore.h
@@ -144,7 +144,6 @@ class PatriciaTreeNode {
 
  protected:
   PatriciaTreeNode(bool is_leaf) : m_reference_count(is_leaf ? LEAF_MASK : 0) {}
-  ~PatriciaTreeNode() = default;
 
  private:
   friend void intrusive_ptr_add_ref(const PatriciaTreeNode* p) {

--- a/sparta/include/PatriciaTreeMapAbstractPartition.h
+++ b/sparta/include/PatriciaTreeMapAbstractPartition.h
@@ -98,11 +98,14 @@ class PatriciaTreeMapAbstractPartition final
    */
   PatriciaTreeMapAbstractPartition& set(const Label& label,
                                         const Domain& value) {
-    if (is_top()) {
-      return *this;
-    }
-    m_map.insert_or_assign(label, value);
-    return *this;
+    return set_internal(label, value);
+  }
+
+  /*
+   * This is a no-op if the partition is set to Top.
+   */
+  PatriciaTreeMapAbstractPartition& set(const Label& label, Domain&& value) {
+    return set_internal(label, std::move(value));
   }
 
   /*
@@ -227,6 +230,16 @@ class PatriciaTreeMapAbstractPartition final
   }
 
  private:
+  template <typename D>
+  PatriciaTreeMapAbstractPartition& set_internal(const Label& label,
+                                                 D&& value) {
+    if (is_top()) {
+      return *this;
+    }
+    m_map.insert_or_assign(label, std::forward<D>(value));
+    return *this;
+  }
+
   MapType m_map;
   bool m_is_top{false};
 };

--- a/sparta/include/PatriciaTreeSet.h
+++ b/sparta/include/PatriciaTreeSet.h
@@ -67,6 +67,8 @@ class PatriciaTreeSet final {
 
   PatriciaTreeSet() = default;
 
+  explicit PatriciaTreeSet(Element e) { insert(std::move(e)); }
+
   explicit PatriciaTreeSet(std::initializer_list<Element> l) {
     for (Element x : l) {
       insert(x);

--- a/sparta/include/PatriciaTreeSetAbstractDomain.h
+++ b/sparta/include/PatriciaTreeSetAbstractDomain.h
@@ -32,11 +32,11 @@ class SetValue final
  public:
   SetValue() = default;
 
-  SetValue(const Element& e) { m_set.insert(e); }
+  SetValue(Element e) : m_set(std::move(e)) {}
 
   SetValue(std::initializer_list<Element> l) : m_set(l.begin(), l.end()) {}
 
-  SetValue(const PatriciaTreeSet<Element>& set) : m_set(set) {}
+  SetValue(PatriciaTreeSet<Element> set) : m_set(std::move(set)) {}
 
   const PatriciaTreeSet<Element>& elements() const override { return m_set; }
 
@@ -45,6 +45,8 @@ class SetValue final
   bool contains(const Element& e) const override { return m_set.contains(e); }
 
   void add(const Element& e) override { m_set.insert(e); }
+
+  void add(Element&& e) override { m_set.insert(std::move(e)); }
 
   void remove(const Element& e) override { m_set.remove(e); }
 
@@ -135,16 +137,16 @@ class PatriciaTreeSetAbstractDomain final
                                const PatriciaTreeSet<Element>&,
                                PatriciaTreeSetAbstractDomain>(kind) {}
 
-  explicit PatriciaTreeSetAbstractDomain(const Element& e) {
-    this->set_to_value(Value(e));
+  explicit PatriciaTreeSetAbstractDomain(Element e) {
+    this->set_to_value(Value(std::move(e)));
   }
 
   explicit PatriciaTreeSetAbstractDomain(std::initializer_list<Element> l) {
     this->set_to_value(Value(l));
   }
 
-  explicit PatriciaTreeSetAbstractDomain(const PatriciaTreeSet<Element>& set) {
-    this->set_to_value(Value(set));
+  explicit PatriciaTreeSetAbstractDomain(PatriciaTreeSet<Element> set) {
+    this->set_to_value(Value(std::move(set)));
   }
 
   static PatriciaTreeSetAbstractDomain bottom() {

--- a/sparta/include/PowersetAbstractDomain.h
+++ b/sparta/include/PowersetAbstractDomain.h
@@ -42,6 +42,7 @@ class PowersetImplementation : public AbstractValue<Derived> {
   virtual bool contains(const Element& e) const = 0;
 
   virtual void add(const Element& e) = 0;
+  virtual void add(Element&& e) = 0;
 
   virtual void remove(const Element& e) = 0;
 
@@ -108,6 +109,12 @@ class PowersetAbstractDomain
   void add(const Element& e) {
     if (this->kind() == AbstractValueKind::Value) {
       this->get_value()->add(e);
+    }
+  }
+
+  void add(Element&& e) {
+    if (this->kind() == AbstractValueKind::Value) {
+      this->get_value()->add(std::move(e));
     }
   }
 

--- a/sparta/include/PowersetAbstractDomain.h
+++ b/sparta/include/PowersetAbstractDomain.h
@@ -16,6 +16,13 @@
 #include "AbstractDomain.h"
 
 namespace sparta {
+namespace pad_impl {
+template <typename Element,
+          typename Powerset,
+          typename Snapshot,
+          typename Derived>
+class PowersetAbstractDomainStaticAssert;
+} // namespace pad_impl
 
 /*
  * The definition of an abstract value belonging to a powerset abstract domain.
@@ -68,23 +75,12 @@ template <typename Element,
           typename Snapshot,
           typename Derived>
 class PowersetAbstractDomain
-    : public AbstractDomainScaffolding<Powerset, Derived> {
+    : public AbstractDomainScaffolding<Powerset, Derived>,
+      private pad_impl::PowersetAbstractDomainStaticAssert<Element,
+                                                           Powerset,
+                                                           Snapshot,
+                                                           Derived> {
  public:
-  virtual ~PowersetAbstractDomain() {
-    // The destructor is the only method that is guaranteed to be created when a
-    // class template is instantiated. This is a good place to perform all the
-    // sanity checks on the template parameters.
-    static_assert(
-        std::is_base_of<PowersetImplementation<Element, Snapshot, Powerset>,
-                        Powerset>::value,
-        "Powerset doesn't inherit from PowersetImplementation");
-    static_assert(
-        std::is_base_of<
-            PowersetAbstractDomain<Element, Powerset, Snapshot, Derived>,
-            Derived>::value,
-        "Derived doesn't inherit from PowersetAbstractDomain");
-  }
-
   /*
    * This constructor produces the empty set, which is distinct from Bottom.
    */
@@ -200,5 +196,28 @@ class PowersetAbstractDomain
     return o;
   }
 };
+
+namespace pad_impl {
+
+template <typename Element,
+          typename Powerset,
+          typename Snapshot,
+          typename Derived>
+class PowersetAbstractDomainStaticAssert {
+ protected:
+  ~PowersetAbstractDomainStaticAssert() {
+    static_assert(
+        std::is_base_of_v<PowersetImplementation<Element, Snapshot, Powerset>,
+                          Powerset>,
+        "Powerset doesn't inherit from PowersetImplementation");
+    static_assert(
+        std::is_base_of_v<
+            PowersetAbstractDomain<Element, Powerset, Snapshot, Derived>,
+            Derived>,
+        "Derived doesn't inherit from PowersetAbstractDomain");
+  }
+};
+
+} // namespace pad_impl
 
 } // namespace sparta

--- a/sparta/include/ReducedProductAbstractDomain.h
+++ b/sparta/include/ReducedProductAbstractDomain.h
@@ -108,7 +108,7 @@ class ReducedProductAbstractDomain
    * to the constructor circumvents the issue without sacrificing readability.
    */
   explicit ReducedProductAbstractDomain(std::tuple<Domains...> product)
-      : DirectProductAbstractDomain<Derived, Domains...>(product) {
+      : DirectProductAbstractDomain<Derived, Domains...>(std::move(product)) {
     // Since one or more components can be _|_, we need to normalize the
     // representation.
     normalize();

--- a/sparta/include/SparseSetAbstractDomain.h
+++ b/sparta/include/SparseSetAbstractDomain.h
@@ -93,6 +93,8 @@ class SparseSetValue final
     }
   }
 
+  void add(IntegerType&& element) override { add(element); }
+
   void remove(const IntegerType& element) override {
     if (element < m_capacity) {
       size_t dense_idx = m_sparse[element];

--- a/sparta/include/SparseSetAbstractDomain.h
+++ b/sparta/include/SparseSetAbstractDomain.h
@@ -200,15 +200,10 @@ class SparseSetAbstractDomain final
  public:
   using Value = ssad_impl::SparseSetValue<IntegerType>;
 
-  ~SparseSetAbstractDomain() {
-    // The destructor is the only method that is guaranteed to be created when
-    // a class template is instantiated. This is a good place to perform all
-    // the sanity checks on the template parameters.
-    static_assert(std::is_unsigned<IntegerType>::value,
-                  "IntegerType is not an unsigned arihmetic type");
-    static_assert(sizeof(IntegerType) <= sizeof(size_t),
-                  "IntegerType is too large");
-  }
+  static_assert(std::is_unsigned_v<IntegerType>,
+                "IntegerType is not an unsigned arihmetic type");
+  static_assert(sizeof(IntegerType) <= sizeof(size_t),
+                "IntegerType is too large");
 
   SparseSetAbstractDomain()
       : PowersetAbstractDomain<IntegerType,

--- a/util/TemplateUtil.h
+++ b/util/TemplateUtil.h
@@ -11,20 +11,6 @@
 
 namespace template_util {
 
-// Extract the first type in a parameter pack.
-template <typename Head, typename... Tail>
-struct HeadType {
-  using type = Head;
-};
-
-// Check if all template parameters are true.
-// See
-// https://stackoverflow.com/questions/28253399/check-traits-for-all-variadic-template-arguments/28253503#28253503
-template <bool...>
-struct bool_pack;
-template <bool... v>
-using all_true = std::is_same<bool_pack<true, v...>, bool_pack<v..., true>>;
-
 template <typename...>
 struct contains;
 


### PR DESCRIPTION
Summary: Allow the node deletion code to be kept behind a function call, so that the simpler and more common atomic decrement can be inlined.

Reviewed By: NTillmann

Differential Revision: D39355686

