### PR TITLE
Fix RemoveUninstantiablesPass in face of Proguard stripping

### DIFF
--- a/libredex/ConfigFiles.cpp
+++ b/libredex/ConfigFiles.cpp
@@ -31,8 +31,8 @@ ConfigFiles::ConfigFiles(const Json::Value& config, const std::string& outdir)
           new ProguardMap(config.get("proguard_map", "").asString(),
                           config.get("use_new_rename_map", 0).asBool())),
       m_printseeds(config.get("printseeds", "").asString()),
-      m_method_profiles(new method_profiles::MethodProfiles()),
-      m_secondary_method_profiles(new method_profiles::MethodProfiles()) {
+      m_method_profiles(new method_profiles::MethodProfiles(*m_proguard_map)),
+      m_secondary_method_profiles(new method_profiles::MethodProfiles(*m_proguard_map)) {
 
   m_coldstart_class_filename = config.get("coldstart_classes", "").asString();
   if (m_coldstart_class_filename.empty()) {

--- a/libredex/ConfigFiles.cpp
+++ b/libredex/ConfigFiles.cpp
@@ -49,6 +49,11 @@ ConfigFiles::ConfigFiles(const Json::Value& config, const std::string& outdir)
   m_instruction_size_bitwidth_limit = instruction_size_bitwidth_limit;
 }
 
+ConfigFiles::ConfigFiles(const Json::Value& config, std::istream& proguard_input) : ConfigFiles(config, "") {
+  m_proguard_map = std::make_unique<ProguardMap>(proguard_input);
+  m_method_profiles = std::make_unique<method_profiles::MethodProfiles>(*m_proguard_map);
+}
+
 ConfigFiles::ConfigFiles(const Json::Value& config) : ConfigFiles(config, "") {}
 
 ConfigFiles::~ConfigFiles() {

--- a/libredex/ConfigFiles.h
+++ b/libredex/ConfigFiles.h
@@ -46,6 +46,8 @@ class MethodProfiles;
  */
 struct ConfigFiles {
   explicit ConfigFiles(const Json::Value& config);
+  // For test purposes to inject a ProguardMap without a stand-alone file
+  explicit ConfigFiles(const Json::Value& config, std::istream& proguard_input);
   ConfigFiles(const Json::Value& config, const std::string& outdir);
   ~ConfigFiles();
 

--- a/libredex/DexHasher.cpp
+++ b/libredex/DexHasher.cpp
@@ -231,7 +231,7 @@ void Impl::hash(const IRCode* c) {
 
 void Impl::hash(const cfg::ControlFlowGraph& cfg) {
   hash(cfg.get_registers_size());
-  hash(cfg.entry_block()->id());
+  hash((uint64_t)cfg.entry_block()->id());
   std::unordered_map<const MethodItemEntry*, uint32_t> mie_ids;
   std::unordered_map<DexPosition*, uint32_t> pos_ids;
   for (auto b : cfg.blocks()) {

--- a/libredex/MethodProfiles.cpp
+++ b/libredex/MethodProfiles.cpp
@@ -198,7 +198,8 @@ std::optional<MethodProfiles::ParsedMain> MethodProfiles::parse_main_internal(
     case NAME:
       // We move the string to a unique_ptr, so that its location is pinned, and
       // the string_views of the mdt are defined.
-      result.ref_str = std::make_unique<std::string>(cell);
+      result.ref_str = std::make_unique<std::string>(
+        m_pg_map.translate_method(std::string(cell)));
       result.mdt =
           dex_member_refs::parse_method</*kCheckFormat=*/true>(*result.ref_str);
       result.ref = DexMethod::get_method(*result.mdt);

--- a/libredex/MethodProfiles.h
+++ b/libredex/MethodProfiles.h
@@ -11,6 +11,7 @@
 #include <string_view>
 
 #include "DexClass.h"
+#include "ProguardMap.h"
 #include "Timer.h"
 #include "Trace.h"
 
@@ -60,7 +61,8 @@ const std::string COLD_START = "ColdStart";
 
 class MethodProfiles {
  public:
-  MethodProfiles() {}
+  MethodProfiles(): m_pg_map(std::move(ProguardMap())) {}
+  MethodProfiles(const ProguardMap& pg_map): m_pg_map(pg_map) {}
 
   void initialize(const std::vector<std::string>& csv_filenames) {
     m_initialized = true;
@@ -136,6 +138,7 @@ class MethodProfiles {
 
  private:
   static AccumulatingTimer s_process_unresolved_lines_timer;
+  const ProguardMap& m_pg_map;
   AllInteractions m_method_stats;
   // Resolution may fail because of renaming or generated methods. Store the
   // unresolved lines here (per interaction) so we can update after passes run

--- a/opt/remove-uninstantiables/RemoveUninstantiablesPass.h
+++ b/opt/remove-uninstantiables/RemoveUninstantiablesPass.h
@@ -14,7 +14,7 @@ namespace cfg {
 class ControlFlowGraph;
 } // namespace cfg
 
-std::unordered_map<std::string, DexType*> make_deobfuscated_map(const std::unordered_set<DexType*>& obfuscated_types);
+std::unordered_map<std::string_view, DexType*> make_deobfuscated_map(const std::unordered_set<DexType*>& obfuscated_types);
 
 class UsageHandler {
  public:
@@ -38,7 +38,7 @@ class UsageHandler {
 
   void handle_usage_line(
     const std::string& line,
-    const std::unordered_map<std::string, DexType*>& deobfuscated_uninstantiable_type,
+    const std::unordered_map<std::string_view, DexType*>& deobfuscated_uninstantiable_type,
     std::unordered_set<DexType*>& uninstantiable_types);
 };
 


### PR DESCRIPTION
This was the original problem that caused https://github.com/facebook/redex/issues/718.

`RemoveUninstantiablesPass` is sensitive to the presence/absence of constructors in its analysis. Proguard will sometimes strip constructors out of classes and cause unsafe optimizations to occur where too many classes removed.

Helpfully, Proguard can output a `usage.txt` which lists the classes, methods, and fields that were stripped. Using that file, we can inform the optimization of the existence of constructors so that it is more conservative in what it removes.

Note that this was packaged together from a modified internal branch for public upstreaming so there might be some strangeness that needs to be polished.