### PR TITLE
Fix missing `#include <fstream>` in ReachableNatives.cpp

### DIFF
--- a/opt/reachable-natives/ReachableNatives.cpp
+++ b/opt/reachable-natives/ReachableNatives.cpp
@@ -12,6 +12,7 @@
 #include <boost/bimap/unordered_set_of.hpp>
 #include <boost/optional/optional.hpp>
 #include <boost/range/adaptor/map.hpp>
+#include <fstream>
 #include <iterator>
 #include <string>
 


### PR DESCRIPTION
Summary: Reported on github. Must be included indirectly somewhere in our internal build. In any case, should fix.

Differential Revision: D44270283

