### PR TITLE
Use 4 threads for toolchain setup

### DIFF
--- a/get_boost.sh
+++ b/get_boost.sh
@@ -27,4 +27,4 @@ tar --bzip2 -xf "$BOOST_TAR_LOCAL"
 
 cd "$BOOST_DIR"
 ./bootstrap.sh --with-libraries=filesystem,iostreams,program_options,regex,system,thread
-./b2 -d0 install
+./b2 -j 4 -d0 install

--- a/setup_oss_toolchain.sh
+++ b/setup_oss_toolchain.sh
@@ -47,7 +47,7 @@ function install_protobuf3_from_source {
 
     pushd protobuf-3.17.3
     ./configure
-    make V=0 && make install V=0
+    make -j 4 V=0 && make install V=0
 }
 
 function install_from_apt {


### PR DESCRIPTION
Summary: Default to 4 threads for Boost and Protobuf builds.

Reviewed By: jimmycFB

Differential Revision: D47154733

