### PR TITLE
Promote "Do not use static boost runtime"

### DIFF
--- a/cmake_modules/Commons.cmake
+++ b/cmake_modules/Commons.cmake
@@ -41,7 +41,7 @@ macro(add_dependent_packages_for_redex)
 
     if(ENABLE_STATIC)
         set(Boost_USE_STATIC_LIBS ON)
-        if(NOT APPLE)
+        if((NOT APPLE) AND (NOT MINGW))
             set(Boost_USE_STATIC_RUNTIME ON)
         endif()
         set(Boost_USE_MULTITHREADED ON)


### PR DESCRIPTION
Summary: Promote {D46959547}.

Differential Revision: D47171356

