### PR TITLE
Fix format strings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,6 @@ DISABLED_WARNINGS = \
   $(DISABLED_WARNINGS_HARD) \
   -Wno-class-memaccess \
   -Wno-deprecated-declarations \
-  -Wno-format \
   -Wno-format-truncation \
   -Wno-format-zero-length \
   -Wno-invalid-offsetof \

--- a/libredex/ControlFlow.cpp
+++ b/libredex/ControlFlow.cpp
@@ -1773,7 +1773,7 @@ std::vector<Block*> ControlFlowGraph::order(
                                 : wto_chains(std::move(wto));
 
   always_assert_log(result.size() == m_blocks.size(),
-                    "result has %lu blocks, m_blocks has %lu", result.size(),
+                    "result has %zu blocks, m_blocks has %zu", result.size(),
                     m_blocks.size());
 
   // The entry block must always be first.

--- a/libredex/DexLoader.cpp
+++ b/libredex/DexLoader.cpp
@@ -32,7 +32,7 @@ static void validate_dex_header(const dex_header* dh,
                                 size_t dexsize,
                                 int support_dex_version) {
   always_assert_log(sizeof(dex_header) <= dexsize,
-                    "Header size (%lu) is larger than file size (%zu)\n",
+                    "Header size (%zu) is larger than file size (%zu)\n",
                     dexsize,
                     sizeof(dex_header));
   bool supported = false;

--- a/libredex/DexOutput.cpp
+++ b/libredex/DexOutput.cpp
@@ -574,14 +574,14 @@ DexOutput::DexOutput(
 
   always_assert_log(
       m_dodx->method_to_idx().size() <= kMaxMethodRefs,
-      "Trying to encode too many method refs in dex %s: %lu (limit: %lu). Run "
+      "Trying to encode too many method refs in dex %s: %zu (limit: %zu). Run "
       "with check_properties_deep turned on.",
       boost::filesystem::path(path).filename().c_str(),
       m_dodx->method_to_idx().size(),
       kMaxMethodRefs);
   always_assert_log(
       m_dodx->field_to_idx().size() <= kMaxFieldRefs,
-      "Trying to encode too many field refs in dex %s: %lu (limit: %lu). Run "
+      "Trying to encode too many field refs in dex %s: %zu (limit: %zu). Run "
       "with check_properties_deep turned on.",
       boost::filesystem::path(path).filename().c_str(),
       m_dodx->field_to_idx().size(),
@@ -897,9 +897,9 @@ void DexOutput::emit_magic_locators() {
 void DexOutput::generate_type_data() {
   always_assert_log(
       m_dodx->type_to_idx().size() < get_max_type_refs(m_min_sdk),
-      "Trying to encode too many type refs in dex %lu: %lu (limit: %lu).\n"
+      "Trying to encode too many type refs in dex %zu: %zu (limit: %zu).\n"
       "NOTE: Please check InterDexPass config flags and set: "
-      "`reserved_trefs: %lu` (or larger, until the issue goes away)",
+      "`reserved_trefs: %zu` (or larger, until the issue goes away)",
       m_dex_number,
       m_dodx->type_to_idx().size(),
       get_max_type_refs(m_min_sdk),

--- a/libredex/MethodDevirtualizer.cpp
+++ b/libredex/MethodDevirtualizer.cpp
@@ -212,7 +212,7 @@ void MethodDevirtualizer::staticize_methods_not_using_this(
     const std::unordered_set<DexMethod*>& methods) {
   fix_call_sites(scope, methods, m_metrics, true /* drop_this */);
   make_methods_static(methods, false);
-  TRACE(VIRT, 1, "Staticized %lu methods not using this", methods.size());
+  TRACE(VIRT, 1, "Staticized %zu methods not using this", methods.size());
   m_metrics.num_methods_not_using_this += methods.size();
 }
 
@@ -221,7 +221,7 @@ void MethodDevirtualizer::staticize_methods_using_this(
     const std::unordered_set<DexMethod*>& methods) {
   fix_call_sites(scope, methods, m_metrics, false /* drop_this */);
   make_methods_static(methods, true);
-  TRACE(VIRT, 1, "Staticized %lu methods using this", methods.size());
+  TRACE(VIRT, 1, "Staticized %zu methods using this", methods.size());
   m_metrics.num_methods_using_this += methods.size();
 }
 
@@ -234,7 +234,7 @@ DevirtualizerMetrics MethodDevirtualizer::devirtualize_methods(
   verify_and_split(vmethods, using_this, not_using_this);
   TRACE(VIRT,
         2,
-        " VIRT to devirt vmethods using this %lu, not using this %lu",
+        " VIRT to devirt vmethods using this %zu, not using this %zu",
         using_this.size(),
         not_using_this.size());
 
@@ -253,7 +253,7 @@ DevirtualizerMetrics MethodDevirtualizer::devirtualize_methods(
   verify_and_split(dmethods, using_this, not_using_this);
   TRACE(VIRT,
         2,
-        " VIRT to devirt dmethods using this %lu, not using this %lu",
+        " VIRT to devirt dmethods using this %zu, not using this %zu",
         using_this.size(),
         not_using_this.size());
 

--- a/libredex/PassManager.cpp
+++ b/libredex/PassManager.cpp
@@ -474,7 +474,7 @@ class JNINativeContextHelper {
       }
     });
 
-    TRACE(NATIVE, 2, "Total removable natives: %lu",
+    TRACE(NATIVE, 2, "Total removable natives: %zu",
           m_removable_natives.size());
 
     auto removable_natives_file_name = conf.metafile(REMOVABLE_NATIVES);

--- a/libredex/ProguardMatcher.cpp
+++ b/libredex/ProguardMatcher.cpp
@@ -280,7 +280,7 @@ class KeepRuleMatcher {
         m_regex_map(regex_map) {}
 
   ~KeepRuleMatcher() {
-    TRACE(PGR, 3, "%s matched %lu classes and %lu members",
+    TRACE(PGR, 3, "%s matched %zu classes and %zu members",
           show_keep(m_keep_rule).c_str(), m_class_matches, m_member_matches);
   }
 

--- a/libredex/VirtualScope.cpp
+++ b/libredex/VirtualScope.cpp
@@ -382,7 +382,7 @@ void merge(const BaseSigs& base_sigs,
           for (const auto& scope : scopes) {
             TRACE(VIRT,
                   4,
-                  "- copy %s (%s:%s): (%ld) %s",
+                  "- copy %s (%s:%s): (%zu) %s",
                   SHOW(scope.type),
                   SHOW(name),
                   SHOW(proto),
@@ -400,7 +400,7 @@ void merge(const BaseSigs& base_sigs,
       always_assert(!virt_scopes.empty());
       TRACE(VIRT,
             4,
-            "- found existing scopes for %s:%s (%ld) - first: %s, %ld, %ld",
+            "- found existing scopes for %s:%s (%zu) - first: %s, %zu, %zu",
             SHOW(name),
             SHOW(proto),
             virt_scopes.size(),
@@ -416,7 +416,7 @@ void merge(const BaseSigs& base_sigs,
         // with that of base which is now the top definition
         TRACE(VIRT,
               4,
-              "-- checking scope type %s(%ld)",
+              "-- checking scope type %s(%zu)",
               SHOW(scope.type),
               scope.methods.size());
         TRACE(VIRT,
@@ -429,7 +429,7 @@ void merge(const BaseSigs& base_sigs,
             !is_interface(type_class(scope.type))) {
           TRACE(VIRT,
                 4,
-                "-- merging with base scopes %s(%ld) : %s",
+                "-- merging with base scopes %s(%zu) : %s",
                 SHOW(virt_scopes[0].type),
                 virt_scopes[0].methods.size(),
                 SHOW(virt_scopes[0].methods[0].first));
@@ -758,7 +758,7 @@ void get_root_scopes(const SignatureMap& sig_map,
                      const DexType* type,
                      Scopes& cls_scopes) {
   const std::vector<DexMethod*>& methods = get_vmethods(type);
-  TRACE(VIRT, 9, "found %ld vmethods for %s", methods.size(), SHOW(type));
+  TRACE(VIRT, 9, "found %zu vmethods for %s", methods.size(), SHOW(type));
   for (const auto meth : methods) {
     const auto& protos = sig_map.find(meth->get_name());
     always_assert(protos != sig_map.end());

--- a/opt/access-marking/AccessMarking.cpp
+++ b/opt/access-marking/AccessMarking.cpp
@@ -194,25 +194,25 @@ void AccessMarkingPass::run_pass(DexStoresVector& stores,
   if (m_finalize_classes) {
     auto n_classes_final = mark_classes_final(scope);
     pm.incr_metric("finalized_classes", n_classes_final);
-    TRACE(ACCESS, 1, "Finalized %lu classes", n_classes_final);
+    TRACE(ACCESS, 1, "Finalized %zu classes", n_classes_final);
   }
   if (m_finalize_methods) {
     auto n_methods_final = mark_methods_final(scope, *override_graph);
     pm.incr_metric("finalized_methods", n_methods_final);
-    TRACE(ACCESS, 1, "Finalized %lu methods", n_methods_final);
+    TRACE(ACCESS, 1, "Finalized %zu methods", n_methods_final);
   }
   if (m_finalize_unwritten_fields || m_finalize_written_fields) {
     auto n_fields_final = mark_fields_final(
         scope, m_finalize_unwritten_fields, m_finalize_written_fields);
     pm.incr_metric("finalized_fields", n_fields_final);
-    TRACE(ACCESS, 1, "Finalized %lu fields", n_fields_final);
+    TRACE(ACCESS, 1, "Finalized %zu fields", n_fields_final);
   }
   if (m_privatize_methods) {
     auto privates = find_private_methods(scope, *override_graph);
     fix_call_sites_private(scope, privates);
     mark_methods_private(privates);
     pm.incr_metric("privatized_methods", privates.size());
-    TRACE(ACCESS, 1, "Privatized %lu methods", privates.size());
+    TRACE(ACCESS, 1, "Privatized %zu methods", privates.size());
   }
 }
 

--- a/opt/annokill/AnnoKill.cpp
+++ b/opt/annokill/AnnoKill.cpp
@@ -692,20 +692,20 @@ bool AnnoKill::kill_annotations() {
   if (traceEnabled(ANNO, 3)) {
     for (const auto& p : m_build_anno_map) {
       TRACE(
-          ANNO, 3, "Build anno: %lu, %s", p.second, str_copy(p.first).c_str());
+          ANNO, 3, "Build anno: %zu, %s", p.second, str_copy(p.first).c_str());
     }
 
     for (const auto& p : m_runtime_anno_map) {
       TRACE(ANNO,
             3,
-            "Runtime anno: %lu, %s",
+            "Runtime anno: %zu, %s",
             p.second,
             str_copy(p.first).c_str());
     }
 
     for (const auto& p : m_system_anno_map) {
       TRACE(
-          ANNO, 3, "System anno: %lu, %s", p.second, str_copy(p.first).c_str());
+          ANNO, 3, "System anno: %zu, %s", p.second, str_copy(p.first).c_str());
     }
   }
 

--- a/opt/builder_pattern/RemoveBuilderPattern.cpp
+++ b/opt/builder_pattern/RemoveBuilderPattern.cpp
@@ -136,8 +136,8 @@ class RemoveClasses {
     mgr.set_metric(root_name + "_num_total_usages", m_num_usages);
     mgr.set_metric(root_name + "_num_removed_usages", m_num_removed_usages);
 
-    TRACE(BLD_PATTERN, 1, "num_classes_excluded %lu", m_excluded_types.size());
-    TRACE(BLD_PATTERN, 1, "num_classes_removed %lu", m_removed_types.size());
+    TRACE(BLD_PATTERN, 1, "num_classes_excluded %zu", m_excluded_types.size());
+    TRACE(BLD_PATTERN, 1, "num_classes_removed %zu", m_removed_types.size());
     for (const auto& type : m_excluded_types) {
       TRACE(BLD_PATTERN, 2, "Excluded type: %s", SHOW(type));
     }
@@ -149,7 +149,7 @@ class RemoveClasses {
       std::stringstream metric;
       metric << "_num_inline_iteration_" << pair.first;
       mgr.incr_metric(root_name + metric.str(), pair.second);
-      TRACE(BLD_PATTERN, 4, "%s_num_inline_iteration %ld %ld",
+      TRACE(BLD_PATTERN, 4, "%s_num_inline_iteration %zu %zu",
             root_name.c_str(), pair.first, pair.second);
     }
   }
@@ -446,7 +446,7 @@ void RemoveBuilderPatternPass::run_pass(DexStoresVector& stores,
       scope, conf.create_init_class_insns());
 
   for (const auto& root : m_roots) {
-    TRACE(BLD_PATTERN, 1, "removing root %s w/ %ld iterations", SHOW(root),
+    TRACE(BLD_PATTERN, 1, "removing root %s w/ %zu iterations", SHOW(root),
           m_max_num_inline_iteration);
     Timer t("root_iteration");
     RemoveClasses rm_builder_pattern(

--- a/opt/check_breadcrumbs/CheckBreadcrumbs.cpp
+++ b/opt/check_breadcrumbs/CheckBreadcrumbs.cpp
@@ -362,11 +362,11 @@ void Breadcrumbs::report_deleted_types(bool report_only, PassManager& mgr) {
       }
     }
     TRACE(BRCR, 1,
-          "Dangling References in Fields: %ld\n"
-          "Dangling References in Methods: %ld\n"
-          "Dangling References in Type Instructions: %ld\n"
-          "Dangling References in Fields Field Instructions: %ld\n"
-          "Dangling References in Method Instructions: %ld\n",
+          "Dangling References in Fields: %zu\n"
+          "Dangling References in Methods: %zu\n"
+          "Dangling References in Type Instructions: %zu\n"
+          "Dangling References in Fields Field Instructions: %zu\n"
+          "Dangling References in Method Instructions: %zu\n",
           bad_fields_count, bad_methods_count, bad_type_insns_count,
           bad_field_insns_count, bad_meths_insns_count);
     TRACE(BRCR, 2, "%s", ss.str().c_str());
@@ -531,12 +531,12 @@ void Breadcrumbs::report_illegal_refs(bool fail_if_illegal_refs,
 
   TRACE(BRCR,
         1,
-        "Illegal fields : %ld\n"
-        "Illegal type refs : %ld\n"
-        "Illegal field type refs : %ld\n"
-        "Illegal field cls refs : %ld\n"
-        "Illegal method calls : %ld\n"
-        "Illegal method defs : %ld\n",
+        "Illegal fields : %zu\n"
+        "Illegal type refs : %zu\n"
+        "Illegal field type refs : %zu\n"
+        "Illegal field cls refs : %zu\n"
+        "Illegal method calls : %zu\n"
+        "Illegal method defs : %zu\n",
         num_illegal_fields,
         num_illegal_type_refs,
         num_illegal_field_type_refs,
@@ -554,12 +554,12 @@ void Breadcrumbs::report_illegal_refs(bool fail_if_illegal_refs,
                  m_types_with_allowed_violations.size());
   TRACE(BRCR,
         1,
-        "Allowed Illegal fields : %ld\n"
-        "Allowed Illegal type refs : %ld\n"
-        "Allowed Illegal field type refs : %ld\n"
-        "Allowed Illegal field cls refs : %ld\n"
-        "Allowed Illegal method calls : %ld\n"
-        "Allowed Illegal method defs : %ld\n",
+        "Allowed Illegal fields : %zu\n"
+        "Allowed Illegal type refs : %zu\n"
+        "Allowed Illegal field type refs : %zu\n"
+        "Allowed Illegal field cls refs : %zu\n"
+        "Allowed Illegal method calls : %zu\n"
+        "Allowed Illegal method defs : %zu\n",
         num_allowed_illegal_fields,
         sum_instructions(allowed_illegal_type),
         sum_instructions(allowed_illegal_field_type),

--- a/opt/class-merging/ClassMergingPass.cpp
+++ b/opt/class-merging/ClassMergingPass.cpp
@@ -275,7 +275,7 @@ void ClassMergingPass::bind_config() {
       m_model_specs.emplace_back(std::move(model));
     }
 
-    TRACE(CLMG, 2, "[ClassMerging] valid model specs %ld",
+    TRACE(CLMG, 2, "[ClassMerging] valid model specs %zu",
           m_model_specs.size());
   });
 }

--- a/opt/delinit/DelInit.cpp
+++ b/opt/delinit/DelInit.cpp
@@ -356,7 +356,7 @@ void DeadRefs::find_unreachable(Scope& scope) {
     vmethods += p.second.vmethods.size();
     ifields += p.second.ifields.size();
   }
-  TRACE(DELINIT, 2, "Uninstantiable classes %ld: vmethods %ld, ifields %ld",
+  TRACE(DELINIT, 2, "Uninstantiable classes %zu: vmethods %zu, ifields %zu",
         classes.size(), vmethods, ifields);
 }
 
@@ -419,7 +419,7 @@ void DeadRefs::collect_dmethods(Scope& scope) {
     acc.initmethods += p.second.initmethods;
     acc.dmethods += p.second.dmethods;
   }
-  TRACE(DELINIT, 3, "Found %ld init and %ld dmethods", acc.initmethods,
+  TRACE(DELINIT, 3, "Found %zu init and %zu dmethods", acc.initmethods,
         acc.dmethods);
 }
 
@@ -486,7 +486,7 @@ void DeadRefs::track_callers(Scope& scope) {
       ci.ifields.erase(ifield);
     }
   });
-  TRACE(DELINIT, 3, "Unreachable (not called) %ld vmethods and %ld ifields",
+  TRACE(DELINIT, 3, "Unreachable (not called) %zu vmethods and %zu ifields",
         vmethods, ifields);
 }
 

--- a/opt/final_inline/FinalInline.cpp
+++ b/opt/final_inline/FinalInline.cpp
@@ -139,7 +139,7 @@ class FinalInlineImpl {
     }
     TRACE(FINALINLINE,
           1,
-          "Removable fields %lu/%lu",
+          "Removable fields %zu/%zu",
           dead_fields.size(),
           moveable_fields.size());
 
@@ -373,7 +373,7 @@ class FinalInlineImpl {
     // Attach encoded values and remove the clinit
     TRACE(FINALINLINE,
           8,
-          "Replacing <clinit> %s: %lu pairs...",
+          "Replacing <clinit> %s: %zu pairs...",
           SHOW(clinit),
           const_sputs.size());
     for (auto& pair : const_sputs) {
@@ -427,7 +427,7 @@ class FinalInlineImpl {
     }
     TRACE(FINALINLINE,
           1,
-          "Replaced %lu/%lu clinits with encoded values",
+          "Replaced %zu/%zu clinits with encoded values",
           nreplaced,
           ntotal);
     return nreplaced;
@@ -527,7 +527,7 @@ class FinalInlineImpl {
       }
     }
     TRACE(
-        FINALINLINE, 1, "Resolved %lu static finals via const prop", nresolved);
+        FINALINLINE, 1, "Resolved %zu static finals via const prop", nresolved);
     return nresolved;
   }
 

--- a/opt/instrument/BlockInstrument.cpp
+++ b/opt/instrument/BlockInstrument.cpp
@@ -1418,7 +1418,7 @@ MethodInfo instrument_basic_blocks(
           info.num_non_entry_blocks - info.rejected_blocks.size()) {
     TRACE(INSTRUMENT, 7, "Post condition violation! in %s", SHOW(method));
     TRACE(INSTRUMENT, 7, "- Instrumented type: %d",
-          get_instrumented_type(info));
+          (int)get_instrumented_type(info));
     TRACE(INSTRUMENT, 7, "  %zu != %zu - %zu", num_to_instrument,
           info.num_non_entry_blocks, info.rejected_blocks.size());
     TRACE(INSTRUMENT, 7, "  original non-entry blocks: %zu",

--- a/opt/interdex/InterDex.cpp
+++ b/opt/interdex/InterDex.cpp
@@ -168,12 +168,12 @@ void print_stats(DexesStructure* dexes_structure) {
         dexes_structure->get_num_scroll_dexes());
 
   TRACE(IDEX, 2, "Global stats:");
-  TRACE(IDEX, 2, "\t %lu classes", dexes_structure->get_num_classes());
-  TRACE(IDEX, 2, "\t %lu mrefs", dexes_structure->get_num_mrefs());
-  TRACE(IDEX, 2, "\t %lu frefs", dexes_structure->get_num_frefs());
-  TRACE(IDEX, 2, "\t %lu dmethods", dexes_structure->get_num_dmethods());
-  TRACE(IDEX, 2, "\t %lu vmethods", dexes_structure->get_num_vmethods());
-  TRACE(IDEX, 2, "\t %lu mrefs", dexes_structure->get_num_mrefs());
+  TRACE(IDEX, 2, "\t %zu classes", dexes_structure->get_num_classes());
+  TRACE(IDEX, 2, "\t %zu mrefs", dexes_structure->get_num_mrefs());
+  TRACE(IDEX, 2, "\t %zu frefs", dexes_structure->get_num_frefs());
+  TRACE(IDEX, 2, "\t %zu dmethods", dexes_structure->get_num_dmethods());
+  TRACE(IDEX, 2, "\t %zu vmethods", dexes_structure->get_num_vmethods());
+  TRACE(IDEX, 2, "\t %zu mrefs", dexes_structure->get_num_mrefs());
 }
 
 /**

--- a/opt/kotlin-lambda/KotlinObjectInliner.cpp
+++ b/opt/kotlin-lambda/KotlinObjectInliner.cpp
@@ -617,15 +617,15 @@ void KotlinObjectInliner::Stats::report(PassManager& mgr) const {
   TRACE(KOTLIN_OBJ_INLINE, 2, "KotlinObjectInliner Stats:");
   TRACE(KOTLIN_OBJ_INLINE,
         2,
-        "kotlin_candidate_companion_objects = %lu",
+        "kotlin_candidate_companion_objects = %zu",
         kotlin_candidate_companion_objects);
   TRACE(KOTLIN_OBJ_INLINE,
         2,
-        "kotlin_untrackable_companion_objects = %lu",
+        "kotlin_untrackable_companion_objects = %zu",
         kotlin_untrackable_companion_objects);
   TRACE(KOTLIN_OBJ_INLINE,
         2,
-        "kotlin_companion_objects_inlined = %lu",
+        "kotlin_companion_objects_inlined = %zu",
         kotlin_companion_objects_inlined);
 }
 

--- a/opt/obfuscate/Obfuscate.cpp
+++ b/opt/obfuscate/Obfuscate.cpp
@@ -249,9 +249,9 @@ void obfuscate(Scope& scope,
   debug_logging(scope);
 
   TRACE(OBFUSCATE, 1,
-        "%s: %ld\n%s: %ld\n"
-        "%s: %ld\n%s: %ld\n"
-        "%s: %ld\n%s: %ld",
+        "%s: %zu\n%s: %zu\n"
+        "%s: %zu\n%s: %zu\n"
+        "%s: %zu\n%s: %zu",
         METRIC_FIELD_TOTAL, stats.fields_total, METRIC_FIELD_RENAMED,
         stats.fields_renamed, METRIC_DMETHODS_TOTAL, stats.dmethods_total,
         METRIC_DMETHODS_RENAMED, stats.dmethods_renamed, METRIC_VMETHODS_TOTAL,

--- a/opt/obfuscate/VirtualRenamer.cpp
+++ b/opt/obfuscate/VirtualRenamer.cpp
@@ -40,7 +40,7 @@ void scope_info(const ClassScopes& class_scopes) {
         if (cls == nullptr || cls->is_external()) return;
         auto scope_meth_count = scope->methods.size();
         if (scope_meth_count > 100) {
-          TRACE(OBFUSCATE, 2, "BIG SCOPE: %ld on %s", scope_meth_count,
+          TRACE(OBFUSCATE, 2, "BIG SCOPE: %zu on %s", scope_meth_count,
                 SHOW(scope->methods[0].first));
         }
         // class is internal
@@ -71,9 +71,9 @@ void scope_info(const ClassScopes& class_scopes) {
   };
   TRACE(OBFUSCATE, 2,
         "scopes (scope count, method count)"
-        "easy (%ld, %ld), "
-        "impl (%ld, %ld), "
-        "can't rename (%ld, %ld)\n",
+        "easy (%zu, %zu), "
+        "impl (%zu, %zu), "
+        "can't rename (%zu, %zu)\n",
         scope_count(easy_scopes), method_count(easy_scopes),
         scope_count(impl_scopes), method_count(impl_scopes),
         scope_count(cant_rename_scopes), method_count(cant_rename_scopes));
@@ -342,7 +342,7 @@ int VirtualRenamer::rename_interface_scopes(int& seed) {
           const TypeSet& intfs) {
         // if any scope cannot be renamed let it go, we don't
         // rename anything
-        TRACE(OBFUSCATE, 5, "Got %ld scopes for %s%s", scopes.size(),
+        TRACE(OBFUSCATE, 5, "Got %zu scopes for %s%s", scopes.size(),
               SHOW(name), SHOW(proto));
         for (auto& scope : scopes) {
           redex_assert(type_class(scope->type) != nullptr);
@@ -441,7 +441,7 @@ int VirtualRenamer::rename_virtual_scopes(const DexType* type, int& seed) {
               });
     // rename all scopes at this level that are not interface
     // and can be renamed
-    TRACE(OBFUSCATE, 5, "Found %ld scopes in %s", scopes_copy.size(),
+    TRACE(OBFUSCATE, 5, "Found %zu scopes in %s", scopes_copy.size(),
           SHOW(type));
     for (auto& scope : scopes_copy) {
       if (!can_rename_scope(scope)) {
@@ -560,12 +560,12 @@ size_t rename_virtuals(
   const auto obj_t = type::java_lang_Object();
   int seed = 0;
   size_t renamed = vr.rename_virtual_scopes(obj_t, seed);
-  TRACE(OBFUSCATE, 2, "Virtual renamed: %ld", renamed);
+  TRACE(OBFUSCATE, 2, "Virtual renamed: %zu", renamed);
 
   // rename interfaces
   std::unordered_set<const VirtualScope*> visited;
   size_t intf_renamed = vr.rename_interface_scopes(seed);
-  TRACE(OBFUSCATE, 2, "Interface renamed: %ld", intf_renamed);
+  TRACE(OBFUSCATE, 2, "Interface renamed: %zu", intf_renamed);
   TRACE(OBFUSCATE, 2, "MAX seed: %d", seed);
   return renamed + intf_renamed;
 }

--- a/opt/optimize_enums/EnumTransformer.cpp
+++ b/opt/optimize_enums/EnumTransformer.cpp
@@ -1063,18 +1063,18 @@ class EnumTransformer final {
       auto attributes = optimize_enums::analyze_enum_clinit(enum_cls);
       size_t num_enum_constants = attributes.m_constants_map.size();
       if (num_enum_constants == 0) {
-        TRACE(ENUM, 2, "\tCannot analyze enum %s : ord %lu sfields %lu",
+        TRACE(ENUM, 2, "\tCannot analyze enum %s : ord %zu sfields %zu",
               SHOW(enum_cls), num_enum_constants,
               enum_cls->get_sfields().size());
         continue;
       } else if (num_enum_constants > config.max_enum_size) {
         if (!config.breaking_reference_equality_allowlist.count(*it)) {
-          TRACE(ENUM, 2, "\tSkip %s %lu values", SHOW(enum_cls),
+          TRACE(ENUM, 2, "\tSkip %s %zu values", SHOW(enum_cls),
                 num_enum_constants);
           continue;
         } else {
           TRACE(ENUM, 2,
-                "\tOptimimze %s (%lu values) but object equality is not "
+                "\tOptimimze %s (%zu values) but object equality is not "
                 "guaranteed",
                 SHOW(enum_cls), num_enum_constants);
         }

--- a/opt/optimize_enums/EnumUpcastAnalysis.cpp
+++ b/opt/optimize_enums/EnumUpcastAnalysis.cpp
@@ -420,8 +420,8 @@ class EnumUpcastDetector {
     type = const_cast<DexType*>(type::get_element_type_if_array(type));
     if (m_candidate_enums->count_unsafe(type)) {
       m_reject_fn(type, reason);
-      TRACE(ENUM, 9, "reject %s %d %s %s", SHOW(type), reason, SHOW(m_method),
-            SHOW(insn));
+      TRACE(ENUM, 9, "reject %s %d %s %s", SHOW(type), (int)reason,
+            SHOW(m_method), SHOW(insn));
     }
   }
 

--- a/opt/peephole/Peephole.cpp
+++ b/opt/peephole/Peephole.cpp
@@ -387,7 +387,7 @@ struct Matcher {
       bool retry = (match_index == 1);
       TRACE(PEEPHOLE,
             8,
-            "Not Matched: %s[%lu] != %s",
+            "Not Matched: %s[%zu] != %s",
             pattern.name.c_str(),
             match_index,
             SHOW(insn));
@@ -404,7 +404,7 @@ struct Matcher {
 
     TRACE(PEEPHOLE,
           8,
-          "Matched [%lu/%lu]: %s",
+          "Matched [%zu/%zu]: %s",
           match_index + 1,
           pattern.match.size(),
           SHOW(insn));
@@ -642,7 +642,7 @@ struct Matcher {
         }
         default:
           not_reached_log("Unexpected string directive: 0x%x",
-                          replace_info.string);
+                          (int)replace_info.string);
         }
       } else if (replace_info.kind == DexPattern::Kind::literal) {
         switch (replace_info.literal) {
@@ -688,7 +688,8 @@ struct Matcher {
           replace->set_type(matched_types.at(Type::B));
           break;
         default:
-          not_reached_log("Unexpected type directive 0x%x", replace_info.type);
+          not_reached_log("Unexpected type directive 0x%x",
+                          (int)replace_info.type);
         }
       } else if (replace_info.kind == DexPattern::Kind::field) {
         switch (replace_info.field) {
@@ -700,7 +701,7 @@ struct Matcher {
           break;
         default:
           not_reached_log("Unexpected field directive 0x%x",
-                          replace_info.field);
+                          (int)replace_info.field);
         }
       }
     }

--- a/opt/rebindrefs/ReBindRefs.cpp
+++ b/opt/rebindrefs/ReBindRefs.cpp
@@ -68,7 +68,7 @@ struct Rebinder {
     void insert(T tin) { insert(tin, T()); }
 
     void print(const char* tag, PassManager& mgr) const {
-      TRACE(BIND, 1, "%11s [call sites: %6d, old refs: %6lu, new refs: %6lu]",
+      TRACE(BIND, 1, "%11s [call sites: %6d, old refs: %6zu, new refs: %6zu]",
             tag, count, in.size(), out.size());
 
       using std::string;

--- a/opt/regalloc/RegAlloc.cpp
+++ b/opt/regalloc/RegAlloc.cpp
@@ -37,15 +37,15 @@ void RegAllocPass::run_pass(DexStoresVector& stores,
     return graph_coloring::allocate(allocator_config, m);
   });
 
-  TRACE(REG, 1, "Total reiteration count: %lu", stats.reiteration_count);
-  TRACE(REG, 1, "Total Params spilled early: %lu", stats.params_spill_early);
-  TRACE(REG, 1, "Total spill count: %lu", stats.moves_inserted());
-  TRACE(REG, 1, "  Total param spills: %lu", stats.param_spill_moves);
-  TRACE(REG, 1, "  Total range spills: %lu", stats.range_spill_moves);
-  TRACE(REG, 1, "  Total global spills: %lu", stats.global_spill_moves);
-  TRACE(REG, 1, "  Total splits: %lu", stats.split_moves);
-  TRACE(REG, 1, "Total coalesce count: %lu", stats.moves_coalesced);
-  TRACE(REG, 1, "Total net moves: %ld", stats.net_moves());
+  TRACE(REG, 1, "Total reiteration count: %zu", stats.reiteration_count);
+  TRACE(REG, 1, "Total Params spilled early: %zu", stats.params_spill_early);
+  TRACE(REG, 1, "Total spill count: %zu", stats.moves_inserted());
+  TRACE(REG, 1, "  Total param spills: %zu", stats.param_spill_moves);
+  TRACE(REG, 1, "  Total range spills: %zu", stats.range_spill_moves);
+  TRACE(REG, 1, "  Total global spills: %zu", stats.global_spill_moves);
+  TRACE(REG, 1, "  Total splits: %zu", stats.split_moves);
+  TRACE(REG, 1, "Total coalesce count: %zu", stats.moves_coalesced);
+  TRACE(REG, 1, "Total net moves: %zu", stats.net_moves());
 
   mgr.incr_metric("param spilled too early", stats.params_spill_early);
   mgr.incr_metric("reiteration_count", stats.reiteration_count);

--- a/opt/remove-interfaces/RemoveInterfacePass.cpp
+++ b/opt/remove-interfaces/RemoveInterfacePass.cpp
@@ -390,7 +390,7 @@ MethodOrderedSet find_dispatch_targets(const TypeSystem& type_system,
   MethodOrderedSet targets;
   for (const auto& virt_scope : intf_scope) {
     auto top_def = virt_scope->methods.front();
-    TRACE(RM_INTF, 5, "Scanning virt scope %s[%ld]", SHOW(top_def.first),
+    TRACE(RM_INTF, 5, "Scanning virt scope %s[%zu]", SHOW(top_def.first),
           virt_scope->methods.size());
     std::vector<const DexType*> matched;
     for (const auto impl : implementors) {
@@ -542,7 +542,7 @@ void RemoveInterfacePass::remove_interfaces_for_root(
       exclude_unremovables(scope, stores, type_system, m_include_primary_dex,
                            m_excluded_interfaces, interfaces);
 
-  TRACE(RM_INTF, 5, "removable interfaces %ld", interfaces.size());
+  TRACE(RM_INTF, 5, "removable interfaces %zu", interfaces.size());
   TypeSet removed =
       remove_leaf_interfaces(scope, root, interfaces, type_system);
 
@@ -551,7 +551,7 @@ void RemoveInterfacePass::remove_interfaces_for_root(
       interfaces.erase(intf);
       m_removed_interfaces.insert(intf);
     }
-    TRACE(RM_INTF, 5, "non-leaf removable interfaces %ld", interfaces.size());
+    TRACE(RM_INTF, 5, "non-leaf removable interfaces %zu", interfaces.size());
     removed = remove_leaf_interfaces(scope, root, interfaces, type_system);
   }
 
@@ -595,10 +595,10 @@ void RemoveInterfacePass::run_pass(DexStoresVector& stores,
   mgr.incr_metric("num_total_interface", m_total_num_interface);
   mgr.incr_metric("num_interface_excluded", m_num_interface_excluded);
   mgr.incr_metric("num_interface_removed", m_num_interface_removed);
-  TRACE(RM_INTF, 5, "total number of interfaces %ld", m_total_num_interface);
-  TRACE(RM_INTF, 5, "number of excluded interfaces %ld",
+  TRACE(RM_INTF, 5, "total number of interfaces %zu", m_total_num_interface);
+  TRACE(RM_INTF, 5, "number of excluded interfaces %zu",
         m_num_interface_excluded);
-  TRACE(RM_INTF, 5, "number of removed interfaces %ld",
+  TRACE(RM_INTF, 5, "number of removed interfaces %zu",
         m_num_interface_removed);
 
   for (const auto& stat : m_dispatch_stats) {

--- a/opt/remove-unreachable/RemoveUnreachable.cpp
+++ b/opt/remove-unreachable/RemoveUnreachable.cpp
@@ -199,7 +199,7 @@ void RemoveUnreachablePassBase::run_pass(DexStoresVector& stores,
       m_remove_no_argument_constructors);
 
   reachability::ObjectCounts before = reachability::count_objects(stores);
-  TRACE(RMU, 1, "before: %lu classes, %lu fields, %lu methods",
+  TRACE(RMU, 1, "before: %zu classes, %zu fields, %zu methods",
         before.num_classes, before.num_fields, before.num_methods);
   pm.set_metric("before.num_classes", before.num_classes);
   pm.set_metric("before.num_fields", before.num_fields);
@@ -240,7 +240,7 @@ void RemoveUnreachablePassBase::run_pass(DexStoresVector& stores,
   }
 
   reachability::ObjectCounts after = reachability::count_objects(stores);
-  TRACE(RMU, 1, "after: %lu classes, %lu fields, %lu methods",
+  TRACE(RMU, 1, "after: %zu classes, %zu fields, %zu methods",
         after.num_classes, after.num_fields, after.num_methods);
   pm.incr_metric("num_ignore_check_strings", num_ignore_check_strings);
   pm.incr_metric("classes_removed", before.num_classes - after.num_classes);

--- a/opt/remove-unused-fields/RemoveUnusedFields.cpp
+++ b/opt/remove-unused-fields/RemoveUnusedFields.cpp
@@ -137,7 +137,7 @@ class RemoveUnusedFields final {
       auto& stats = pair.second;
       TRACE(RMUF,
             3,
-            "%s: %lu %lu %d",
+            "%s: %zu %zu %d",
             SHOW(field),
             stats.reads,
             stats.writes,

--- a/opt/remove_empty_classes/RemoveEmptyClasses.cpp
+++ b/opt/remove_empty_classes/RemoveEmptyClasses.cpp
@@ -157,7 +157,7 @@ Stats remove_empty_classes(Scope& classes) {
                 classes.end());
 
   auto num_classes_removed = classes_before_size - classes.size();
-  TRACE(EMPTY, 1, "Empty classes removed: %ld", num_classes_removed);
+  TRACE(EMPTY, 1, "Empty classes removed: %zu", num_classes_removed);
   return Stats{num_classes_removed, clinit_removed.load()};
 }
 

--- a/opt/renameclasses/RenameClassesV2.cpp
+++ b/opt/renameclasses/RenameClassesV2.cpp
@@ -78,7 +78,7 @@ const char* dont_rename_reason_to_metric(DontRenameReasonCode reason) {
   case DontRenameReasonCode::SerdeRelationships:
     return "num_dont_rename_serde_relationships";
   default:
-    not_reached_log("Unexpected DontRenameReasonCode: %d", reason);
+    not_reached_log("Unexpected DontRenameReasonCode: %d", (int)reason);
   }
 }
 

--- a/opt/resolve-refs/SpecializeRtype.cpp
+++ b/opt/resolve-refs/SpecializeRtype.cpp
@@ -305,7 +305,7 @@ void RtypeSpecialization::specialize_true_virtuals(
       if (can_update_rtype_for(overridden, better_rtype) &&
           share_common_rtype_candidate(m_candidates, global_overridings,
                                        better_rtype)) {
-        TRACE(RESO, 4, "global overrides %ld -> %s ", global_overridings.size(),
+        TRACE(RESO, 4, "global overrides %zu -> %s ", global_overridings.size(),
               SHOW(better_rtype));
         DexProto* updated_proto =
             DexProto::make_proto(better_rtype, meth->get_proto()->get_args());

--- a/opt/shorten-srcstrings/Shorten.cpp
+++ b/opt/shorten-srcstrings/Shorten.cpp
@@ -122,7 +122,7 @@ static void strip_src_strings(DexStoresVector& stores,
     }
   }
 
-  TRACE(SHORTEN, 1, "src strings shortened %ld, %lu bytes saved", shortened,
+  TRACE(SHORTEN, 1, "src strings shortened %zu, %zu bytes saved", shortened,
         string_savings);
 
   mgr.incr_metric(METRIC_SHORTENED_STRINGS, shortened);

--- a/opt/singleimpl/SingleImpl.cpp
+++ b/opt/singleimpl/SingleImpl.cpp
@@ -160,8 +160,8 @@ void SingleImplPass::run_pass(DexStoresVector& stores,
   }
 
   TRACE(INTF, 2, "\ttotal steps %d", max_steps);
-  TRACE(INTF, 1, "Removed interfaces %ld", removed_count);
-  TRACE(INTF, 1, "Updated invoke-interface to invoke-virtual %ld",
+  TRACE(INTF, 1, "Removed interfaces %zu", removed_count);
+  TRACE(INTF, 1, "Updated invoke-interface to invoke-virtual %zu",
         s_invoke_intf_count - previous_invoke_intf_count);
 
   mgr.incr_metric(METRIC_REMOVED_INTERFACES, stats.removed_interfaces);

--- a/opt/stringbuilder-outliner/StringBuilderOutliner.cpp
+++ b/opt/stringbuilder-outliner/StringBuilderOutliner.cpp
@@ -244,7 +244,7 @@ void Outliner::create_outline_helpers(DexStoresVector* stores) {
       continue;
     }
     TRACE(STRBUILD, 3,
-          "Outlining %lu StringBuilders of length %lu with typelist %s", count,
+          "Outlining %zu StringBuilders of length %zu with typelist %s", count,
           typelist->size(), SHOW(typelist));
     m_stats.stringbuilders_removed += count;
     m_stats.operations_removed += count * typelist->size();

--- a/opt/unreferenced_interfaces/UnreferencedInterfaces.cpp
+++ b/opt/unreferenced_interfaces/UnreferencedInterfaces.cpp
@@ -252,15 +252,15 @@ void UnreferencedInterfacesPass::run_pass(DexStoresVector& stores,
   update_scope(removable, scope);
   post_dexen_changes(scope, stores);
 
-  TRACE(UNREF_INTF, 1, "candidates %ld", m_metric.candidates);
-  TRACE(UNREF_INTF, 1, "on abstract classes %ld", m_metric.on_abstract_cls);
-  TRACE(UNREF_INTF, 1, "field references %ld", m_metric.field_refs);
-  TRACE(UNREF_INTF, 1, "signature references %ld", m_metric.sig_refs);
-  TRACE(UNREF_INTF, 1, "instruction references %ld", m_metric.insn_refs);
-  TRACE(UNREF_INTF, 1, "annotation references %ld", m_metric.anno_refs);
-  TRACE(UNREF_INTF, 1, "unresolved methods %ld", m_metric.unresolved_meths);
-  TRACE(UNREF_INTF, 1, "updated implementations %ld", m_metric.updated_impls);
-  TRACE(UNREF_INTF, 1, "removable %ld", m_metric.removed);
+  TRACE(UNREF_INTF, 1, "candidates %zu", m_metric.candidates);
+  TRACE(UNREF_INTF, 1, "on abstract classes %zu", m_metric.on_abstract_cls);
+  TRACE(UNREF_INTF, 1, "field references %zu", m_metric.field_refs);
+  TRACE(UNREF_INTF, 1, "signature references %zu", m_metric.sig_refs);
+  TRACE(UNREF_INTF, 1, "instruction references %zu", m_metric.insn_refs);
+  TRACE(UNREF_INTF, 1, "annotation references %zu", m_metric.anno_refs);
+  TRACE(UNREF_INTF, 1, "unresolved methods %zu", m_metric.unresolved_meths);
+  TRACE(UNREF_INTF, 1, "updated implementations %zu", m_metric.updated_impls);
+  TRACE(UNREF_INTF, 1, "removable %zu", m_metric.removed);
 
   mgr.set_metric("on abstract classes", m_metric.on_abstract_cls);
   mgr.set_metric("updated implementations", m_metric.updated_impls);

--- a/service/class-merging/ApproximateShapeMerging.cpp
+++ b/service/class-merging/ApproximateShapeMerging.cpp
@@ -271,7 +271,7 @@ void simple_greedy_approximation(const JsonWrapper& specs,
   size_t max_distance;
   specs.get("distance", 0, max_distance);
   TRACE(CLMG, 3, "[approx] Using simple greedy algorithm.");
-  TRACE(CLMG, 3, "         distance = %ld.", max_distance);
+  TRACE(CLMG, 3, "         distance = %zu.", max_distance);
 
   // Sort shapes by the number of fields.
   std::vector<Shape> shapes_list;

--- a/service/class-merging/ClassMerging.cpp
+++ b/service/class-merging/ClassMerging.cpp
@@ -140,7 +140,7 @@ ModelStats merge_model(const TypeSystem& type_system,
   always_assert(s_is_initialized);
   TRACE(CLMG,
         2,
-        "[ClassMerging] merging %s model merging targets %lu roots %lu",
+        "[ClassMerging] merging %s model merging targets %zu roots %zu",
         spec.name.c_str(),
         spec.merging_targets.size(),
         spec.roots.size());

--- a/service/class-merging/MergeabilityCheck.cpp
+++ b/service/class-merging/MergeabilityCheck.cpp
@@ -249,27 +249,27 @@ TypeSet MergeabilityChecker::get_non_mergeables() {
   size_t prev_size = 0;
 
   exclude_unsupported_cls_property(non_mergeables);
-  TRACE(CLMG, 4, "Non mergeables (no delete) %ld", non_mergeables.size());
+  TRACE(CLMG, 4, "Non mergeables (no delete) %zu", non_mergeables.size());
   prev_size = non_mergeables.size();
 
   exclude_unsupported_bytecode(non_mergeables);
   TRACE(CLMG,
         4,
-        "Non mergeables (opcodes) %ld",
+        "Non mergeables (opcodes) %zu",
         non_mergeables.size() - prev_size);
   prev_size = non_mergeables.size();
 
   exclude_static_fields(non_mergeables);
   TRACE(CLMG,
         4,
-        "Non mergeables (static fields) %ld",
+        "Non mergeables (static fields) %zu",
         non_mergeables.size() - prev_size);
   prev_size = non_mergeables.size();
 
   exclude_unsafe_sdk_and_store_refs(non_mergeables);
   TRACE(CLMG,
         4,
-        "Non mergeables (unsafe refs) %ld",
+        "Non mergeables (unsafe refs) %zu",
         non_mergeables.size() - prev_size);
   return non_mergeables;
 }

--- a/service/class-merging/Model.cpp
+++ b/service/class-merging/Model.cpp
@@ -99,10 +99,10 @@ void print_interface_maps(const TypeToTypeSet& intf_to_classes,
             });
   for (const auto& intf : intfs) {
     const auto& classes = intf_to_classes.at(intf);
-    TRACE(CLMG, 8, "- interface %s -> %ld", SHOW(intf), classes.size());
+    TRACE(CLMG, 8, "- interface %s -> %zu", SHOW(intf), classes.size());
     if (classes.size() <= 5) {
       for (const auto& cls : classes) {
-        TRACE(CLMG, 8, "\t-(%ld) %s", types.count(cls), SHOW(cls));
+        TRACE(CLMG, 8, "\t-(%zu) %s", types.count(cls), SHOW(cls));
       }
     }
   }
@@ -116,14 +116,14 @@ size_t trim_shapes(MergerType::ShapeCollector& shapes, size_t min_count) {
   std::vector<MergerType::Shape> shapes_to_remove;
   for (const auto& shape_it : shapes) {
     if (shape_it.second.types.size() >= min_count) {
-      TRACE(CLMG, 7, "Keep shape %s (%ld)", shape_it.first.to_string().c_str(),
+      TRACE(CLMG, 7, "Keep shape %s (%zu)", shape_it.first.to_string().c_str(),
             shape_it.second.types.size());
       continue;
     }
     shapes_to_remove.push_back(shape_it.first);
   }
   for (const auto& shape : shapes_to_remove) {
-    TRACE(CLMG, 7, "Drop shape %s (%ld)", shape.to_string().c_str(),
+    TRACE(CLMG, 7, "Drop shape %s (%zu)", shape.to_string().c_str(),
           shapes[shape].types.size());
     num_trimmed_types += shapes[shape].types.size();
     shapes.erase(shape);
@@ -141,7 +141,7 @@ size_t trim_groups(MergerType::ShapeCollector& shapes, size_t min_count) {
     std::vector<TypeSet> groups_to_remove;
     for (const auto& group_it : shape_it.second.groups) {
       if (group_it.second.size() >= min_count) {
-        TRACE(CLMG, 7, "Keep group (%ld) on %s", group_it.second.size(),
+        TRACE(CLMG, 7, "Keep group (%zu) on %s", group_it.second.size(),
               shape_it.first.to_string().c_str());
         continue;
       }
@@ -149,7 +149,7 @@ size_t trim_groups(MergerType::ShapeCollector& shapes, size_t min_count) {
     }
     for (const auto& group : groups_to_remove) {
       auto& types = shape_it.second.groups[group];
-      TRACE(CLMG, 7, "Drop group (%ld) on %s", types.size(),
+      TRACE(CLMG, 7, "Drop group (%zu) on %s", types.size(),
             shape_it.first.to_string().c_str());
       num_trimmed_types += types.size();
       for (const auto& type : types) {
@@ -199,11 +199,11 @@ void Model::init(const Scope& scope,
   TypeSet generated;
   load_generated_types(spec, scope, type_system, m_spec.merging_targets,
                        generated);
-  TRACE(CLMG, 4, "Generated types %ld", generated.size());
+  TRACE(CLMG, 4, "Generated types %zu", generated.size());
   exclude_types(spec.exclude_types);
   MergeabilityChecker checker(scope, spec, m_ref_checker, generated);
   m_non_mergeables = checker.get_non_mergeables();
-  TRACE(CLMG, 3, "Non mergeables %ld", m_non_mergeables.size());
+  TRACE(CLMG, 3, "Non mergeables %zu", m_non_mergeables.size());
   m_stats.m_non_mergeables = m_non_mergeables.size();
   m_stats.m_all_types = m_spec.merging_targets.size();
 }
@@ -316,7 +316,7 @@ MergerType& Model::create_merger_shape(
     const DexType* parent,
     const TypeSet& intfs,
     const std::vector<const DexType*>& classes) {
-  TRACE(CLMG, 7, "Create Shape %s - %s, parent %s, intfs %ld, classes %ld",
+  TRACE(CLMG, 7, "Create Shape %s - %s, parent %s, intfs %zu, classes %zu",
         SHOW(shape_type), shape.to_string().c_str(), SHOW(parent), intfs.size(),
         classes.size());
   auto& merger = m_mergers[shape_type];
@@ -425,7 +425,7 @@ void Model::exclude_types(const ConstTypeHashSet& exclude_types) {
       m_type_system.get_all_children(type, m_excluded);
     }
   }
-  TRACE(CLMG, 4, "Excluding types %ld", m_excluded.size());
+  TRACE(CLMG, 4, "Excluding types %zu", m_excluded.size());
 }
 
 bool Model::is_excluded(const DexType* type) const {
@@ -479,7 +479,7 @@ void Model::shape_model() {
 
   // Update excluded metrics
   m_stats.m_excluded = m_excluded.size();
-  TRACE(CLMG, 4, "Excluded types total %ld", m_excluded.size());
+  TRACE(CLMG, 4, "Excluded types total %zu", m_excluded.size());
 }
 
 void Model::shape_merger(const MergerType& root,
@@ -509,7 +509,7 @@ void Model::shape_merger(const MergerType& root,
 
     MergerType::Shape shape(cls->get_ifields());
 
-    TRACE(CLMG, 9, "Shape of %s [%ld]: %s", SHOW(child),
+    TRACE(CLMG, 9, "Shape of %s [%zu]: %s", SHOW(child),
           cls->get_ifields().size(), shape.to_string().c_str());
 
     shapes[shape].types.insert(child);
@@ -535,7 +535,7 @@ void Model::approximate_shapes(MergerType::ShapeCollector& shapes) {
   size_t num_before_shapes = 0;
   TRACE(CLMG, 3, "[approx] Shapes before approximation:");
   for (const auto& s : shapes) {
-    TRACE(CLMG, 3, "         Shape: %s, mergeables = %ld",
+    TRACE(CLMG, 3, "         Shape: %s, mergeables = %zu",
           s.first.to_string().c_str(), s.second.types.size());
     num_before_shapes++;
     num_total_mergeable += s.second.types.size();
@@ -565,7 +565,7 @@ void Model::approximate_shapes(MergerType::ShapeCollector& shapes) {
   size_t num_after_shapes = 0;
   TRACE(CLMG, 3, "[approx] Shapes after approximation:");
   for (const auto& s_pair : shapes) {
-    TRACE(CLMG, 3, "         Shape: %s, mergeables = %ld",
+    TRACE(CLMG, 3, "         Shape: %s, mergeables = %zu",
           s_pair.first.to_string().c_str(), s_pair.second.types.size());
     num_after_shapes++;
     num_total_mergeable -= s_pair.second.types.size();
@@ -595,7 +595,7 @@ void Model::break_by_interface(const MergerType& merger,
     auto& intfs = cls_intfs->second;
     hier.groups[intfs].insert(type);
   }
-  TRACE(CLMG, 7, "%ld groups created for shape %s (%ld)", hier.groups.size(),
+  TRACE(CLMG, 7, "%zu groups created for shape %s (%zu)", hier.groups.size(),
         shape.to_string().c_str(), hier.types.size());
 }
 
@@ -1002,7 +1002,7 @@ void Model::collect_methods() {
     }
     TRACE(CLMG,
           8,
-          "Collect methods for merger %s [%ld]",
+          "Collect methods for merger %s [%zu]",
           SHOW(merger.type),
           merger.mergeables.size());
     for (const auto* mergeable : merger.mergeables) {
@@ -1011,7 +1011,7 @@ void Model::collect_methods() {
       TRACE(CLMG, 8, "  mergeable %s", SHOW(mergeable));
       TRACE(CLMG,
             8,
-            "%ld dmethods in %s",
+            "%zu dmethods in %s",
             cls->get_dmethods().size(),
             SHOW(cls->get_type()));
       bool has_ctor = false;
@@ -1026,7 +1026,7 @@ void Model::collect_methods() {
                         SHOW(mergeable));
 
       const auto& virt_scopes = m_type_system.get_class_scopes().get(mergeable);
-      TRACE(CLMG, 8, "%ld virtual scopes in %s", virt_scopes.size(),
+      TRACE(CLMG, 8, "%zu virtual scopes in %s", virt_scopes.size(),
             SHOW(mergeable));
       for (const auto* virt_scope : virt_scopes) {
 
@@ -1034,7 +1034,7 @@ void Model::collect_methods() {
         if (is_impl_scope(virt_scope)) {
           TRACE(CLMG,
                 8,
-                "interface virtual scope [%ld]",
+                "interface virtual scope [%zu]",
                 virt_scope->methods.size());
           add_interface_scope(merger, *virt_scope);
           continue;
@@ -1208,7 +1208,7 @@ void Model::distribute_virtual_methods(
     const DexType* type, std::vector<const VirtualScope*> base_scopes) {
   TRACE(CLMG,
         8,
-        "distribute virtual methods for %s, parent virtual scope %ld",
+        "distribute virtual methods for %s, parent virtual scope %zu",
         SHOW(type),
         base_scopes.size());
   // add to the base_scope the class scope of the merger type
@@ -1220,7 +1220,7 @@ void Model::distribute_virtual_methods(
     }
     TRACE(CLMG,
           8,
-          "virtual scope found [%ld] %s",
+          "virtual scope found [%zu] %s",
           virt_scope->methods.size(),
           SHOW(virt_scope->methods[0].first));
     base_scopes.emplace_back(virt_scope);
@@ -1235,7 +1235,7 @@ void Model::distribute_virtual_methods(
     for (const auto& virt_scope : base_scopes) {
       TRACE(CLMG,
             8,
-            "walking virtual scope [%s, %ld] %s (%s)",
+            "walking virtual scope [%s, %zu] %s (%s)",
             SHOW(virt_scope->type),
             virt_scope->methods.size(),
             virt_scope->methods[0]
@@ -1489,7 +1489,7 @@ std::string Model::print(const DexType* type, int nest) const {
           if (!intf_meths.overridden_meth) {
             const auto& methods = intf_meths.methods;
             TRACE(CLMG, 8,
-                  "interface method entry missing overridden method %s %ld",
+                  "interface method entry missing overridden method %s %zu",
                   SHOW(methods.front()), methods.size());
           }
         }
@@ -1565,7 +1565,7 @@ void ModelStats::update_redex_stats(const std::string& prefix,
     auto group_size = pair.second;
     mgr.incr_metric(prefix + "_interdex_group_" + std::to_string(group_id),
                     group_size);
-    TRACE(CLMG, 3, "InterDex Group %s_%u %lu", prefix.c_str(), group_id,
+    TRACE(CLMG, 3, "InterDex Group %s_%u %zu", prefix.c_str(), group_id,
           group_size);
   }
 
@@ -1574,7 +1574,7 @@ void ModelStats::update_redex_stats(const std::string& prefix,
     auto count = pair.second;
     mgr.incr_metric(prefix + "_merging_size_" + std::to_string(merging_size),
                     count);
-    TRACE(CLMG, 3, "Merging size %s_%lu %lu", prefix.c_str(), merging_size,
+    TRACE(CLMG, 3, "Merging size %s_%zu %zu", prefix.c_str(), merging_size,
           count);
   }
 

--- a/service/class-merging/ModelMethodMerger.cpp
+++ b/service/class-merging/ModelMethodMerger.cpp
@@ -775,7 +775,7 @@ void ModelMethodMerger::dedup_non_ctor_non_virt_methods() {
           annotated.push_back(m);
         }
       }
-      TRACE(CLMG, 8, "const lift: start %ld", annotated.size());
+      TRACE(CLMG, 8, "const lift: start %zu", annotated.size());
       auto stub_methods = const_lift.lift_constants_from(
           m_scope, m_type_tags, annotated, CONST_LIFT_STUB_THRESHOLD);
       to_dedup.insert(to_dedup.end(), stub_methods.begin(), stub_methods.end());

--- a/service/dedup-blocks/DedupBlocks.cpp
+++ b/service/dedup-blocks/DedupBlocks.cpp
@@ -1150,7 +1150,7 @@ class DedupBlocksImpl {
     TRACE(DEDUP_BLOCKS, 4, "duplicate blocks set: {");
     for (const auto& entry : dups) {
       TRACE(
-          DEDUP_BLOCKS, 4, "  hash = %lu",
+          DEDUP_BLOCKS, 4, "  hash = %zu",
           DedupBlkValueNumbering::BlockValueHasher{}(*entry.first.block_value));
       for (cfg::Block* b : entry.second) {
         TRACE(DEDUP_BLOCKS, 4, "    block %zu", b->id());

--- a/service/local-dce/LocalDce.cpp
+++ b/service/local-dce/LocalDce.cpp
@@ -115,7 +115,7 @@ LocalDce::get_dead_instructions(const cfg::ControlFlowGraph& cfg,
       auto prev_liveness = liveness.at(b->id());
       auto& bliveness = liveness.at(b->id());
       bliveness.reset();
-      TRACE(DCE, 5, "B%lu: %s", b->id(), show(bliveness).c_str());
+      TRACE(DCE, 5, "B%zu: %s", b->id(), show(bliveness).c_str());
 
       // Compute live-out for this block from its successors.
       for (auto& s : b->succs()) {
@@ -124,7 +124,7 @@ LocalDce::get_dead_instructions(const cfg::ControlFlowGraph& cfg,
         }
         TRACE(DCE,
               5,
-              "  S%lu: %s",
+              "  S%zu: %s",
               s->target()->id(),
               SHOW(liveness.at(s->target()->id())));
         bliveness |= liveness.at(s->target()->id());

--- a/service/method-dedup/ConstantLifting.cpp
+++ b/service/method-dedup/ConstantLifting.cpp
@@ -157,7 +157,7 @@ std::vector<DexMethod*> ConstantLifting::lift_constants_from(
   }
   TRACE(METH_DEDUP,
         5,
-        "constant lifting applied to %ld among %ld",
+        "constant lifting applied to %zu among %zu",
         lifted.size(),
         methods.size());
   m_num_const_lifted_methods += lifted.size();

--- a/service/method-dedup/ConstantValue.cpp
+++ b/service/method-dedup/ConstantValue.cpp
@@ -132,7 +132,7 @@ ConstantValues::ConstantValues(const TypeTags* type_tags,
   if (kinds_str.size() > MAX_NUM_CONST_VALUE) {
     TRACE(METH_DEDUP,
           8,
-          "const value: skip large number of const values %ld",
+          "const value: skip large number of const values %zu",
           kinds_str.size());
     return;
   }

--- a/service/method-inliner/MethodInliner.cpp
+++ b/service/method-inliner/MethodInliner.cpp
@@ -280,20 +280,20 @@ std::unordered_set<DexMethod*> gather_non_virtual_methods(
     }
   }
 
-  TRACE(INLINE, 2, "All methods count: %ld", all_methods);
-  TRACE(INLINE, 2, "Direct methods count: %ld", direct_methods);
-  TRACE(INLINE, 2, "Virtual methods count: %ld", all_methods - direct_methods);
-  TRACE(INLINE, 2, "Direct methods no code: %ld", direct_no_code);
-  TRACE(INLINE, 2, "Direct methods with code: %ld",
+  TRACE(INLINE, 2, "All methods count: %zu", all_methods);
+  TRACE(INLINE, 2, "Direct methods count: %zu", direct_methods);
+  TRACE(INLINE, 2, "Virtual methods count: %zu", all_methods - direct_methods);
+  TRACE(INLINE, 2, "Direct methods no code: %zu", direct_no_code);
+  TRACE(INLINE, 2, "Direct methods with code: %zu",
         direct_methods - direct_no_code);
-  TRACE(INLINE, 2, "Constructors with or without code: %ld", init);
-  TRACE(INLINE, 2, "Static constructors: %ld", clinit);
-  TRACE(INLINE, 2, "Static methods: %ld", static_methods);
-  TRACE(INLINE, 2, "Private methods: %ld", private_methods);
-  TRACE(INLINE, 2, "Virtual methods non virtual count: %ld", non_virt_methods);
-  TRACE(INLINE, 2, "Non virtual no code count: %ld", non_virtual_no_code);
-  TRACE(INLINE, 2, "Non virtual no strip count: %ld", non_virt_dont_strip);
-  TRACE(INLINE, 2, "Don't strip inlinable methods count: %ld", dont_strip);
+  TRACE(INLINE, 2, "Constructors with or without code: %zu", init);
+  TRACE(INLINE, 2, "Static constructors: %zu", clinit);
+  TRACE(INLINE, 2, "Static methods: %zu", static_methods);
+  TRACE(INLINE, 2, "Private methods: %zu", private_methods);
+  TRACE(INLINE, 2, "Virtual methods non virtual count: %zu", non_virt_methods);
+  TRACE(INLINE, 2, "Non virtual no code count: %zu", non_virtual_no_code);
+  TRACE(INLINE, 2, "Non virtual no strip count: %zu", non_virt_dont_strip);
+  TRACE(INLINE, 2, "Don't strip inlinable methods count: %zu", dont_strip);
   return methods;
 }
 
@@ -836,39 +836,39 @@ void run_inliner(DexStoresVector& stores,
     }
   }
 
-  TRACE(INLINE, 3, "recursive %ld", inliner.get_info().recursive);
-  TRACE(INLINE, 3, "max_call_stack_depth %ld",
+  TRACE(INLINE, 3, "recursive %zu", inliner.get_info().recursive);
+  TRACE(INLINE, 3, "max_call_stack_depth %zu",
         inliner.get_info().max_call_stack_depth);
-  TRACE(INLINE, 3, "waited seconds %ld", inliner.get_info().waited_seconds);
-  TRACE(INLINE, 3, "blocklisted meths %ld",
+  TRACE(INLINE, 3, "waited seconds %zu", inliner.get_info().waited_seconds);
+  TRACE(INLINE, 3, "blocklisted meths %zu",
         (size_t)inliner.get_info().blocklisted);
-  TRACE(INLINE, 3, "virtualizing methods %ld",
+  TRACE(INLINE, 3, "virtualizing methods %zu",
         (size_t)inliner.get_info().need_vmethod);
-  TRACE(INLINE, 3, "invoke super %ld", (size_t)inliner.get_info().invoke_super);
-  TRACE(INLINE, 3, "escaped virtual %ld",
+  TRACE(INLINE, 3, "invoke super %zu", (size_t)inliner.get_info().invoke_super);
+  TRACE(INLINE, 3, "escaped virtual %zu",
         (size_t)inliner.get_info().escaped_virtual);
-  TRACE(INLINE, 3, "known non public virtual %ld",
+  TRACE(INLINE, 3, "known non public virtual %zu",
         (size_t)inliner.get_info().non_pub_virtual);
-  TRACE(INLINE, 3, "non public ctor %ld",
+  TRACE(INLINE, 3, "non public ctor %zu",
         (size_t)inliner.get_info().non_pub_ctor);
-  TRACE(INLINE, 3, "unknown field %ld",
+  TRACE(INLINE, 3, "unknown field %zu",
         (size_t)inliner.get_info().escaped_field);
-  TRACE(INLINE, 3, "non public field %ld",
+  TRACE(INLINE, 3, "non public field %zu",
         (size_t)inliner.get_info().non_pub_field);
-  TRACE(INLINE, 3, "throws %ld", (size_t)inliner.get_info().throws);
-  TRACE(INLINE, 3, "multiple returns %ld",
+  TRACE(INLINE, 3, "throws %zu", (size_t)inliner.get_info().throws);
+  TRACE(INLINE, 3, "multiple returns %zu",
         (size_t)inliner.get_info().multi_ret);
-  TRACE(INLINE, 3, "references cross stores %ld",
+  TRACE(INLINE, 3, "references cross stores %zu",
         (size_t)inliner.get_info().cross_store);
-  TRACE(INLINE, 3, "api level mismatches %ld",
+  TRACE(INLINE, 3, "api level mismatches %zu",
         (size_t)inliner.get_info().api_level_mismatch);
-  TRACE(INLINE, 3, "illegal references %ld",
+  TRACE(INLINE, 3, "illegal references %zu",
         (size_t)inliner.get_info().problematic_refs);
-  TRACE(INLINE, 3, "not found %ld", (size_t)inliner.get_info().not_found);
-  TRACE(INLINE, 3, "caller too large %ld",
+  TRACE(INLINE, 3, "not found %zu", (size_t)inliner.get_info().not_found);
+  TRACE(INLINE, 3, "caller too large %zu",
         (size_t)inliner.get_info().caller_too_large);
   TRACE(INLINE, 3, "inlined ctors %zu", inlined_init_count);
-  TRACE(INLINE, 1, "%ld inlined calls over %ld methods and %ld methods removed",
+  TRACE(INLINE, 1, "%zu inlined calls over %zu methods and %zu methods removed",
         (size_t)inliner.get_info().calls_inlined, inlined_count,
         deleted.size());
 

--- a/service/regalloc/GraphColoring.cpp
+++ b/service/regalloc/GraphColoring.cpp
@@ -1133,15 +1133,15 @@ void Allocator::allocate(cfg::ControlFlowGraph& cfg, bool is_static) {
     }
   }
 
-  TRACE(REG, 3, "Reiteration count: %lu", m_stats.reiteration_count);
-  TRACE(REG, 3, "Spill count: %lu", m_stats.moves_inserted());
-  TRACE(REG, 3, "  Param spills: %lu", m_stats.param_spill_moves);
-  TRACE(REG, 3, "  Range spills: %lu", m_stats.range_spill_moves);
-  TRACE(REG, 3, "  Global spills: %lu", m_stats.global_spill_moves);
-  TRACE(REG, 3, "  splits: %lu", m_stats.split_moves);
-  TRACE(REG, 3, "Coalesce count: %lu", m_stats.moves_coalesced);
-  TRACE(REG, 3, "Params spilled too early: %lu", m_stats.params_spill_early);
-  TRACE(REG, 3, "Net moves: %ld", m_stats.net_moves());
+  TRACE(REG, 3, "Reiteration count: %zu", m_stats.reiteration_count);
+  TRACE(REG, 3, "Spill count: %zu", m_stats.moves_inserted());
+  TRACE(REG, 3, "  Param spills: %zu", m_stats.param_spill_moves);
+  TRACE(REG, 3, "  Range spills: %zu", m_stats.range_spill_moves);
+  TRACE(REG, 3, "  Global spills: %zu", m_stats.global_spill_moves);
+  TRACE(REG, 3, "  splits: %zu", m_stats.split_moves);
+  TRACE(REG, 3, "Coalesce count: %zu", m_stats.moves_coalesced);
+  TRACE(REG, 3, "Params spilled too early: %zu", m_stats.params_spill_early);
+  TRACE(REG, 3, "Net moves: %zu", m_stats.net_moves());
 }
 
 } // namespace graph_coloring

--- a/service/switch-dispatch/SwitchDispatch.cpp
+++ b/service/switch-dispatch/SwitchDispatch.cpp
@@ -470,7 +470,7 @@ DexMethodRef* create_dispatch_method_ref(
     const std::map<SwitchIndices, DexMethod*>& indices_to_callee) {
 
   if (indices_to_callee.size() < 2) {
-    LOG_AND_RETURN("Not enough methods(should >= 2) in indices_to_callee %lu\n",
+    LOG_AND_RETURN("Not enough methods(should >= 2) in indices_to_callee %zu\n",
                    indices_to_callee.size());
   }
   auto first_method = indices_to_callee.begin()->second;

--- a/tools/redex-tool/AnalyzeThrows.cpp
+++ b/tools/redex-tool/AnalyzeThrows.cpp
@@ -181,7 +181,7 @@ void find_throwing_block(const Scope& scope) {
       }
     }
   });
-  fprintf(stderr, "throwing blocks %ld\n", throwing_blocks.size());
+  fprintf(stderr, "throwing blocks %zu\n", throwing_blocks.size());
   print_blocks_by_size(throwing_blocks);
 }
 

--- a/tools/redex-tool/DexSqlDump.cpp
+++ b/tools/redex-tool/DexSqlDump.cpp
@@ -183,7 +183,7 @@ void dump_method(FILE* fdout,
   const auto& deobfuscated_name = method->get_deobfuscated_name();
   auto method_name = strchr(deobfuscated_name.c_str(), ';');
   fprintf(fdout,
-          "INSERT INTO %smethods VALUES (%d,%d,'%s','%s',%d,%lu);\n",
+          "INSERT INTO %smethods VALUES (%d,%d,'%s','%s',%d,%zu);\n",
           prefix,
           method_id,
           class_id,


### PR DESCRIPTION
Summary: Use `%zu` instead of `%ld` and `%lu`. Also mollify GCC and convert enum classes explicitly to `int`.

Reviewed By: jimmycFB

Differential Revision: D47141332

