### PR TITLE
Yet another GCC warning to disable

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,7 @@ DISABLED_WARNINGS = \
   -Wno-sign-compare \
   -Wno-strict-aliasing \
   -Wno-stringop-overflow \
+  -Wno-stringop-overread \
   -Wno-uninitialized \
   -Wno-unused-but-set-variable \
   -Wno-unused-function \


### PR DESCRIPTION
Summary: Exposed on Ubuntu 22.04's GCC.

Differential Revision: D47215030

