### PR TITLE
Remove dangling print_kotlin_stats_test in make file

### DIFF
--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -543,7 +543,6 @@ TESTS = \
     outliner_type_analysis_test \
     partial_pass_test \
     peephole_test \
-    print_kotlin_stats_test \
     proguard_lexer_test \
     proguard_map_test \
     proguard_parser_test \


### PR DESCRIPTION
Summary: Pass was deleted in D47980468.

Differential Revision: D48123696

