### PR TITLE
Change generating build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,10 @@ commands:
       # It is OK to generically restore boost, even if it is not used.
       - restore_cache:
           keys:
-            - boost-1-71-0-v1
+            - boost-1-71-0-v4
+      - restore_cache:
+          keys:
+            - protobuf3-v2
       - run:
           name: Setup
           command: |
@@ -115,8 +118,12 @@ commands:
           steps:
             - save_cache:
                 paths:
-                  - boost_cache
-                key: boost-1-71-0-v1
+                  - dl_cache/boost_cache
+                key: boost-1-71-0-v4
+            - save_cache:
+                paths:
+                  - dl_cache/protobuf
+                key: protobuf3-v2
 
   # For testing, need additional dependencies not provided by the image.
 
@@ -378,6 +385,7 @@ jobs:
     steps:
       - build_debian:
           use_sdk: false
+          save_boost_cache: true
 
   build-20_04:
     docker:
@@ -385,8 +393,7 @@ jobs:
     # GCC is hungry.
     resource_class: large
     steps:
-      - build_debian:
-          save_boost_cache: true
+      - build_debian
 
   build-22_04:
     docker:

--- a/get_boost.sh
+++ b/get_boost.sh
@@ -9,7 +9,7 @@ BOOST_VERSION="1.71.0"
 BOOST_VERSION_UNDERSCORE="${BOOST_VERSION//./_}"
 BOOST_FILE="boost_${BOOST_VERSION_UNDERSCORE}.tar.bz2"
 BOOST_TAR_URL="https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/${BOOST_FILE}"
-BOOST_CACHE_DIR="boost_cache"
+BOOST_CACHE_DIR="dl_cache/boost_cache"
 BOOST_TAR_LOCAL="${BOOST_CACHE_DIR}/${BOOST_FILE}"
 BOOST_DIR="boost_${BOOST_VERSION_UNDERSCORE}"
 
@@ -17,13 +17,17 @@ set -e
 
 # Check for cached artifacts.
 if [ ! -d "$BOOST_CACHE_DIR" ] ; then
-  mkdir boost_cache
+  mkdir -p "$BOOST_CACHE_DIR"
 fi
 if [ ! -f "$BOOST_TAR_LOCAL" ] ; then
+  echo "Downloading Boost 1.71.0"
   wget "$BOOST_TAR_URL" -O "$BOOST_TAR_LOCAL"
 fi
 
-tar --bzip2 -xf "$BOOST_TAR_LOCAL"
+mkdir -p toolchain_install/boost
+pushd toolchain_install/boost
+
+tar --bzip2 -xf "../../$BOOST_TAR_LOCAL"
 
 cd "$BOOST_DIR"
 ./bootstrap.sh --with-libraries=filesystem,iostreams,program_options,regex,system,thread


### PR DESCRIPTION
Summary:
The cache was misconfigured. A "save" was triggered for Ubuntu 20.04 - which does not build Boost from source. So the cache was empty.

Change the generating build to be Ubuntu 18.04. While this is technically outdated, it is the build we originally pushed. Eventually this should move to the Debian 10 (oldoldstable).

Increase the cache key version.

Differential Revision: D52492772


