### PR TITLE
Copy older cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,10 @@ commands:
       - restore_cache:
           keys:
             - boost-1-71-0-v5
+      # Temporarily to bypass jfrog downtime.
+      - restore_cache:
+          keys:
+            - boost-1-71-0-v4
       - restore_cache:
           keys:
             - protobuf3-v3

--- a/setup_oss_toolchain.sh
+++ b/setup_oss_toolchain.sh
@@ -22,6 +22,12 @@ if [ -z "$TOOLCHAIN_TMP" ] ; then
 else
   echo "Using toolchain tmp $TOOLCHAIN_TMP"
   mkdir -p "$TOOLCHAIN_TMP"
+
+  # Temporarily to bypass jfrog downtime.
+  if [ -d "dl_cache" ] && [ ! -d "$TOOLCHAIN_TMP/dl_cache" ] ; then
+    echo "Copying older cache..."
+    cp -r dl_cache "$TOOLCHAIN_TMP/"
+  fi
 fi
 
 if [ "$1" = "32" ] ; then


### PR DESCRIPTION
Summary: To avoid jfrog being down right now.

Differential Revision: D52626633


