### PR TITLE
Remove abstract/interface assertion

### DIFF
--- a/libredex/CallGraph.cpp
+++ b/libredex/CallGraph.cpp
@@ -182,7 +182,6 @@ RootAndDynamic MultipleCalleeBaseStrategy::get_roots() const {
       for (auto m : overridden_methods) {
         if (!m->is_external()) {
           auto* cls = type_class(m->get_class());
-          always_assert(is_interface(cls) || is_abstract(cls));
           dynamic_methods.emplace(m);
         }
       }


### PR DESCRIPTION
This assertion breaks with trivial examples and appears unnecessary.

### Reviewer note
It appears this assertion can be violated with a fairly mundane setup:

```java
class Internal {
    String process(String input) {
        return "";
    }
}

class External extends Internal {
    @Override
    String process(String input) {
        return "";
    }
}

class Issue extends External {
    void foo(String input) {
        new External().process(input);
    }
}
```

where `Internal` and `Issue` are on the classpath, and `External` is on the libpath. We removed this assertion in our fork and would suggest the same change upstream.