### PR TITLE
Fix some shift-sign-overflow

### DIFF
--- a/libredex/DexOutput.h
+++ b/libredex/DexOutput.h
@@ -313,11 +313,11 @@ class DexOutput {
   enhanced_dex_stats_t m_stats;
 
   static constexpr size_t kIODILayerBits = 4;
-  static constexpr size_t kIODILayerBound = 1 << (kIODILayerBits - 1);
+  static constexpr size_t kIODILayerBound = 1ul << (kIODILayerBits - 1);
   static constexpr size_t kIODILayerShift =
       sizeof(uint32_t) * 8 - kIODILayerBits;
-  static constexpr uint32_t kIODIDataMask = (1 << kIODILayerShift) - 1;
-  static constexpr uint32_t kIODILayerMask = ((1 << kIODILayerBits) - 1)
+  static constexpr uint32_t kIODIDataMask = (1u << kIODILayerShift) - 1;
+  static constexpr uint32_t kIODILayerMask = ((1u << kIODILayerBits) - 1)
                                              << kIODILayerShift;
 
  private:

--- a/libresource/androidfw/ResourceTypes.h
+++ b/libresource/androidfw/ResourceTypes.h
@@ -237,7 +237,7 @@ struct Res_value
         // Where the actual value is.  This gives us 23 bits of
         // precision.  The top bit is the sign.
         COMPLEX_MANTISSA_SHIFT = 8,
-        COMPLEX_MANTISSA_MASK = 0xffffff
+        COMPLEX_MANTISSA_MASK = 0xffffffU
     };
 
     // Possible data values for TYPE_NULL.

--- a/opt/result-propagation/ResultPropagation.cpp
+++ b/opt/result-propagation/ResultPropagation.cpp
@@ -34,7 +34,7 @@ constexpr const char* METRIC_UNVERIFIABLE_MOVE_RESULTS =
     "num_unverifiable_move_results";
 constexpr const char* METRIC_METHODS_WHICH_RETURN_PARAMETER_ITERATIONS =
     "num_methods_which_return_parameters_iterations";
-constexpr const ParamIndex WIDE_HIGH = 1 << 31;
+constexpr const ParamIndex WIDE_HIGH = 1u << 31;
 
 void patch_move_result_to_move(IRInstruction* move_result_inst, reg_t reg) {
   const auto op = move_result_inst->opcode();


### PR DESCRIPTION
The project currently does not compile with `-Wshift-sign-overflow`.

This fixes that, or at least some of it. This will shortly be required for achieving internal compilation.