### PR TITLE
Convert circleci workflows to github actions

### DIFF
--- a/.github/actions/base-build-setup/action.yml
+++ b/.github/actions/base-build-setup/action.yml
@@ -1,0 +1,29 @@
+name: base-build-setup
+inputs:
+  save_boost_cache:
+    required: false
+    default: false
+  setup_toolchain_extra:
+    required: false
+    default: ''
+runs:
+  using: composite
+  steps:
+  - name: Cache boost
+    if: inputs.save_boost_cache == 'true'
+    uses: actions/cache@v3.3.2
+    with:
+      key: boost-1-71-0-v5
+      path: /tmp/toolchain/dl_cache/boost_cache
+  - name: Cache protobuf
+    if: inputs.save_boost_cache == 'true'
+    uses: actions/cache@v3.3.2
+    with:
+      key: protobuf3-v3
+      path: /tmp/toolchain/dl_cache/protobuf
+  - name: Setup
+    run: sudo -E ./setup_oss_toolchain.sh ${{ inputs.setup_toolchain_extra }}
+    working-directory: repo
+    env:
+      TOOLCHAIN_TMP: /tmp/toolchain
+    shell: bash

--- a/.github/actions/build_debian/action.yml
+++ b/.github/actions/build_debian/action.yml
@@ -1,0 +1,40 @@
+name: build_debian
+inputs:
+  save_boost_cache:
+    required: false
+    default: false
+  install_clang:
+    required: false
+    default: false
+  install_clang_llvm_org:
+    required: false
+    default: -1
+  mode_32:
+    required: false
+    default: false
+  use_sdk:
+    required: false
+    default: true
+  job_name:
+    required: false
+runs:
+  using: composite
+  steps:
+  - uses: actions/checkout@v4.1.1
+    with:
+      path: repo
+  - uses: ./.github/actions/debian-based-image-build-setup
+    with:
+      mode_32: "${{ inputs.mode_32 }}"
+      install_clang: "${{ inputs.install_clang }}"
+      install_clang_llvm_org: "${{ inputs.install_clang_llvm_org }}"
+  - name: Run git-restore-mtime
+    run: git restore-mtime
+    working-directory: repo
+    shell: bash
+  - uses: ./.github/actions/setup-build-and-test-w-make
+    with:
+      save_boost_cache: "${{ inputs.save_boost_cache }}"
+      mode_32: "${{ inputs.mode_32 }}"
+      use_sdk: "${{ inputs.use_sdk }}"
+      job_name: "${{ inputs.job_name }}-${{ inputs.install_clang_llvm_org }}"

--- a/.github/actions/debian-based-image-build-setup/action.yml
+++ b/.github/actions/debian-based-image-build-setup/action.yml
@@ -1,0 +1,43 @@
+name: debian-based-image-build-setup
+inputs:
+  mode_32:
+    required: false
+    default: false
+  install_clang:
+    required: false
+    default: false
+  install_clang_llvm_org:
+    required: false
+    default: -1
+runs:
+  using: composite
+  steps:
+  - name: Update Apt Data
+    run: sudo apt-get update || ( apt-get update && apt-get install --no-install-recommends -y sudo ; )
+    shell: bash
+  - name: Install tools
+    run: sudo apt-get install --no-install-recommends -y git-restore-mtime zstd tar
+    shell: bash
+  - name: Add 32-bit Arch
+    run: sudo dpkg --add-architecture i386 && sudo apt-get update
+    if: inputs.mode_32 == 'true'
+    shell: bash
+  - name: Install Clang
+    run: sudo apt-get install -y --no-install-recommends clang
+    if: inputs.install_clang == 'true'
+    shell: bash
+  - name: Install Clang (apt.llvm.org)
+    run: |-
+      sudo apt-get install -y --no-install-recommends lsb-release software-properties-common
+      sudo /bin/bash -c "$(wget -O - https://apt.llvm.org/llvm.sh | sed -e 's/^add-apt-repository.*$/& -y\n& -y/')"
+      ls /usr/bin/clang*
+    if: 0 == inputs.install_clang_llvm_org
+    shell: bash
+
+  - name: Install Clang (apt.llvm.org)
+    run: |-
+      sudo apt-get install -y --no-install-recommends lsb-release software-properties-common
+      sudo /bin/bash -c "$(wget -O - https://apt.llvm.org/llvm.sh | sed -e 's/^add-apt-repository.*$/& -y\n& -y/')" "llvm.sh" ${{ inputs.install_clang_llvm_org }}
+      ls /usr/bin/clang*
+    if: -1 != inputs.install_clang_llvm_org && 0 != inputs.install_clang_llvm_org
+    shell: bash

--- a/.github/actions/setup-build-and-test-w-make-impl/action.yml
+++ b/.github/actions/setup-build-and-test-w-make-impl/action.yml
@@ -1,0 +1,73 @@
+name: setup-build-and-test-w-make-impl
+inputs:
+  setup_toolchain_extra:
+    required: false
+    default: ''
+  configure_extra:
+    required: false
+    default: ''
+  save_boost_cache:
+    required: false
+    default: false
+  run_tests:
+    required: false
+    default: true
+  use_sdk:
+    required: false
+    default: true
+  job_name:
+    required: false
+runs:
+  using: composite
+  steps:
+  - uses: "./.github/actions/base-build-setup"
+    with:
+      save_boost_cache: "${{ inputs.save_boost_cache }}"
+      setup_toolchain_extra: "${{ inputs.setup_toolchain_extra }}"
+  - uses: "./.github/actions/test-build-setup"
+    with:
+      use_sdk: "${{ inputs.use_sdk }}"
+  - name: Create Build Cache File
+    run: echo "${{ inputs.job_name }}.${{ inputs.setup_toolchain_extra }}.${{ inputs.configure_extra }}" > /tmp/build.txt
+    shell: bash
+  - name: Cache build
+    uses: actions/cache@v3.3.2
+    with:
+      key: v1-build-cache-{{ hashFiles('/tmp/build.txt') }}-{{ runner.arch }}-{{ github.ref_name }}-{{ github.sha }}
+      path: build.tar.zstd
+  - name: Create build directory
+    run: |-
+      if [ -f  "build.tar.zstd" ] ; then zstd --decompress --stdout build.tar.zstd | tar xf - ; else mkdir -p build ; fi
+      rm -f build.tar.zstd
+    shell: bash
+  - name: Autoreconf
+    run: autoreconf -ivf
+    working-directory: repo
+    shell: bash
+  - name: Configure
+    run: "../repo/configure --enable-protobuf ${{ inputs.configure_extra }}"
+    working-directory: build
+    shell: bash
+  - name: Build
+    run: make -j4 V=0
+    working-directory: build
+    shell: bash
+  - name: Compress build directory
+    run: tar cf - build | zstd -T0 -3 > build.tar.zstd
+    shell: bash
+  - name: Build tests
+    run: make -j4 check TESTS= V=0
+    working-directory: build
+    shell: bash
+  - name: Run tests
+    run: |-
+      mkdir -p /tmp/test-results
+      export GTEST_OUTPUT=xml:/tmp/test-results/
+      make -j4 check V=0
+    working-directory: build
+    if: inputs.run_test == 'true'
+    shell: bash
+  - uses: actions/upload-artifact@v4.0.0
+    with:
+      path: "/tmp/test-results"
+    if: inputs.run_tests == 'true'

--- a/.github/actions/setup-build-and-test-w-make/action.yml
+++ b/.github/actions/setup-build-and-test-w-make/action.yml
@@ -1,0 +1,32 @@
+name: setup-build-and-test-w-make
+inputs:
+  save_boost_cache:
+    required: false
+    default: false
+  mode_32:
+    required: false
+    default: false
+  use_sdk:
+    required: false
+    default: true
+  job_name:
+    required: false
+runs:
+  using: composite
+  steps:
+  - uses: "./.github/actions/setup-build-and-test-w-make-impl"
+    if: inputs.mode_32 == 'true'
+    with:
+      setup_toolchain_extra: '32'
+      configure_extra: "--host=i686-linux-gnu CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32"
+      save_boost_cache: "${{ inputs.save_boost_cache }}"
+      run_tests: false
+      use_sdk: "${{ inputs.use_sdk }}"
+      job_name: "${{ inputs.job_name }}"
+
+  - uses: "./.github/actions/setup-build-and-test-w-make-impl"
+    if: inputs.mode_32 != 'true'
+    with:
+      save_boost_cache: "${{ inputs.save_boost_cache }}"
+      use_sdk: "${{ inputs.use_sdk }}"
+      job_name: "${{ inputs.job_name }}"

--- a/.github/actions/setup-build-and-test-windows/action.yml
+++ b/.github/actions/setup-build-and-test-windows/action.yml
@@ -1,0 +1,29 @@
+name: setup-build-and-test-windows
+runs:
+  using: composite
+  steps:
+  - name: Install MSYS2
+    uses: msys2/setup-msys2@v2
+    with:
+      msystem: MINGW64
+      pacboy: >-
+        make
+        boost
+        cmake
+        gcc
+        jsoncpp
+        make
+        python
+  - name: Setup
+    run: pacman -S --needed --noconfirm make zip unzip
+    shell: msys2 {0}
+  - name: Build
+    run: mkdir build && cd build && cmake -G "MSYS Makefiles" .. && make -j 4 V=0
+    shell: msys2 {0}
+  - name: Minimal Test
+    run: 'build/redex-all --show-passes | grep -E "Registered passes: [1-9][0-9]*"'
+    shell: msys2 {0}
+
+  - name: Package
+    run: cd build && make -j 4 package V=0
+    shell: msys2 {0}

--- a/.github/actions/test-build-setup-no-sdk/action.yml
+++ b/.github/actions/test-build-setup-no-sdk/action.yml
@@ -1,0 +1,8 @@
+name: test-build-setup-no-sdk
+runs:
+  using: composite
+  steps:
+  - name: Setup for tests
+    run: |-
+      sudo apt-get install -y --no-install-recommends dalvik-exchange default-jdk-headless
+    shell: bash

--- a/.github/actions/test-build-setup-sdk/action.yml
+++ b/.github/actions/test-build-setup-sdk/action.yml
@@ -1,0 +1,43 @@
+name: test-build-setup-sdk
+runs:
+  using: composite
+  steps:
+  - name: Setup for tests (Deb Testing)
+    run: sudo apt-get install -y --no-install-recommends default-jdk-headless
+    shell: bash
+  - name: Set cache version
+    id: cache_version
+    run: |-
+      echo "Cache key is: ${CACHE_VERSION}"
+      echo "CACHE_VERSION=${CACHE_VERSION}" >> "$GITHUB_OUTPUT"
+    shell: bash
+  - name: Cache SDK
+    uses: actions/cache@v3.3.2
+    with:
+      key: android-build-tools-{{ steps.cache_version.outputs.CACHE_VERSION }}
+      path: ~/sdk
+      restore-keys: android-build-tools-{{ steps.cache_version.outputs.CACHE_VERSION }}
+  - name: Check/Install (SDK)
+    run: |-
+      if [ -e ~/sdk/build-tools/25.0.3/dx ] ; then
+        echo "Found SDK."
+        exit 0
+      fi
+      echo "SDK missing, downloading..."
+      rm -rf ~/sdk 2>/dev/null
+      wget https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip
+      mkdir -p ~/sdk/cmdline-tools
+      unzip commandlinetools-linux-6609375_latest.zip -d ~/sdk/cmdline-tools/
+      pushd ~/sdk/cmdline-tools/tools/bin >/dev/null
+      echo 'y' | ./sdkmanager --install 'build-tools;25.0.3'
+      popd >/dev/null
+    shell: bash
+  - name: Check/Install (Symlink)
+    run: |-
+      if [ -L /usr/local/bin/dx ] ; then
+        echo "Found symlink."
+        exit 0
+      fi
+      echo "Adding symlink..."
+      sudo ln -s ~/sdk/build-tools/25.0.3/dx /usr/local/bin/dx
+    shell: bash

--- a/.github/actions/test-build-setup/action.yml
+++ b/.github/actions/test-build-setup/action.yml
@@ -1,0 +1,12 @@
+name: test-build-setup
+inputs:
+  use_sdk:
+    required: false
+    default: true
+runs:
+  using: composite
+  steps:
+  - uses: "./.github/actions/test-build-setup-sdk"
+    if: inputs.use_sdk == 'true'
+  - uses: "./.github/actions/test-build-setup-no-sdk"
+    if: inputs.use_sdk != 'true'

--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -1,0 +1,112 @@
+name: facebook/redex/build_main
+on:
+  pull_request:
+    branches:
+    - main
+    - stable
+  push:
+    branches:
+    - main
+  schedule:
+    - cron: 0 0 * * *
+env:
+  CACHE_VERSION: xxxxx1
+jobs:
+  build-20_04:
+    runs-on: 4-core-ubuntu
+    steps:
+    - uses: actions/checkout@v4.1.1
+    - uses: "./.github/actions/build_debian"
+      with:
+        job_name: ubuntu_20.04
+# `ubuntu-latest` runner out of space
+#  build-22_04:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: actions/checkout@v4.1.1
+#    - uses: "./.github/actions/build_debian"
+#      with:
+#        job_name: ubuntu_22.04
+  build-deb_oldoldstable:
+    runs-on: 4-core-ubuntu
+    steps:
+    - uses: actions/checkout@v4.1.1
+    - uses: "./.github/actions/build_debian"
+      with:
+        use_sdk: true
+        job_name: debian_10
+  build-deb_stable:
+    runs-on: 4-core-ubuntu
+    steps:
+    - uses: actions/checkout@v4.1.1
+    - uses: "./.github/actions/build_debian"
+      with:
+        job_name: debian_12
+# `mode_32` failed on boost lib
+#  build-deb_stable-32:
+#    runs-on: 4-core-ubuntu
+#    steps:
+#    - uses: actions/checkout@v4.1.1
+#    - uses: "./.github/actions/build_debian"
+#      with:
+#        mode_32: true
+#        job_name: debian_12_32
+  build-deb_unstable:
+    runs-on: 4-core-ubuntu
+    steps:
+    - uses: actions/checkout@v4.1.1
+    - uses: "./.github/actions/build_debian"
+      with:
+        job_name: debian_unstable
+  build-deb_stable-w-clang-llvm-org:
+    runs-on: 4-core-ubuntu
+    env:
+      CC: clang
+      CXX: clang++
+    strategy:
+      matrix:
+        clang_version:
+        - 0
+        - 15
+        - 17
+    steps:
+    - uses: actions/checkout@v4.1.1
+    - uses: "./.github/actions/build_debian"
+      with:
+        install_clang_llvm_org: "${{ matrix.clang_version }}"
+        job_name: debian_12_clang_upstream
+  build-windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4.1.1
+    - uses: "./.github/actions/setup-build-and-test-windows"
+  build-windows-artifacts:
+    if: github.event_name == 'schedule'
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4.1.1
+    - uses: "./.github/actions/setup-build-and-test-windows"
+    - name: Copy package for github actions
+      run: mkdir artifacts && mv build/Redex*.zip artifacts/
+      shell: c:/tools/msys64/msys2_shell.cmd -defterm -no-start -mingw64 -full-path -here -c
+    - uses: actions/upload-artifact@v4.0.0
+      with:
+        path: ".\\artifacts"
+  build-deb_stable-w-clang-llvm-org_nightly:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+      CXX: clang++
+    strategy:
+      matrix:
+        clang_version:
+        - 0
+        - 15
+        - 17
+    steps:
+    - uses: actions/checkout@v4.1.1
+    - uses: "./.github/actions/build_debian"
+      with:
+        install_clang_llvm_org: "${{ matrix.clang_version }}"
+        job_name: debian_12_clang_upstream


### PR DESCRIPTION
Summary:
This pull request converts the CircleCI workflows to GitHub actions workflows.

`build-deb_oldoldstable` job fails with the following error.
```
/bin/bash: dx: command not found
```

[Here is the latest workflow run in my fork](https://github.com/robandpdx-org/redex/actions/runs/8351358902).

---
https://fburl.com/workplace/f6mz6tmw

Differential Revision: D55346929


