### PR TITLE
Correctly wire up boost

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,6 +57,10 @@ include $(top_srcdir)/Makefile.inc
 #
 AM_CPPFLAGS = $(COMMON_INCLUDES)
 
+# Boost.
+AM_CPPFLAGS += $(BOOST_CPPFLAGS)
+AM_LDFLAGS = $(BOOST_LDFLAGS)
+
 noinst_LTLIBRARIES = libredex.la libopt.la
 
 BUILT_SOURCES =

--- a/test/integ/Makefile.am
+++ b/test/integ/Makefile.am
@@ -4,6 +4,10 @@ include $(top_srcdir)/test/Makefile.inc
 AM_CXXFLAGS = --std=gnu++17
 AM_CPPFLAGS = $(COMMON_INCLUDES) $(COMMON_TEST_INCLUDES)
 
+# Boost.
+AM_CPPFLAGS += $(BOOST_CPPFLAGS)
+AM_LDFLAGS = $(BOOST_LDFLAGS)
+
 LDADD = $(COMMON_MOCK_TEST_LIBS)
 
 # Need to set "dexfile" environment variable to point to the dex file ised in

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -4,6 +4,10 @@ include $(top_srcdir)/test/Makefile.inc
 AM_CXXFLAGS = --std=gnu++17
 AM_CPPFLAGS = $(COMMON_INCLUDES) $(COMMON_TEST_INCLUDES)
 
+# Boost.
+AM_CPPFLAGS += $(BOOST_CPPFLAGS)
+AM_LDFLAGS = $(BOOST_LDFLAGS)
+
 LDADD = $(COMMON_TEST_LIBS)
 
 # These need things in the environment.


### PR DESCRIPTION
Summary: Correctly wire up the flags needed to compile against Boost (by just adding them to the general flags).

Reviewed By: itang00

Differential Revision: D59553236
