### PR TITLE
Use Android SDK

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,16 +191,6 @@ commands:
             rm -rf sdk/emulator 2>/dev/null
             tar cf - sdk | zstd -T0 -3 > sdk.tar.zstd
 
-      - run:
-          name: Check/Install (Symlink)
-          command: |
-            if [ -L /usr/local/bin/dx ] ; then
-              echo "Found symlink."
-              exit 0
-            fi
-            echo "Adding symlink..."
-            sudo ln -s $(pwd)/sdk/build-tools/29.0.2/dx /usr/local/bin/dx
-
       - save_cache:
           name: Saving SDK Cache
           paths:
@@ -263,7 +253,7 @@ commands:
           name: Configure
           working_directory: build
           command: |
-            ../repo/configure --enable-protobuf << parameters.configure_extra >>
+            ../repo/configure --enable-protobuf --with-android-sdk="$(pwd)/../sdk" << parameters.configure_extra >>
 
       - run:
           name: Build

--- a/.github/actions/setup-build-and-test-w-make-impl/action.yml
+++ b/.github/actions/setup-build-and-test-w-make-impl/action.yml
@@ -40,7 +40,8 @@ runs:
     working-directory: repo
     shell: bash
   - name: Configure
-    run: "../repo/configure --enable-protobuf ${{ inputs.configure_extra }}"
+    run: |-
+      ../repo/configure --enable-protobuf --with-android-sdk="$(pwd)/../sdk" ${{ inputs.configure_extra }}
     working-directory: build
     shell: bash
   - name: Build

--- a/.github/actions/test-build-setup/action.yml
+++ b/.github/actions/test-build-setup/action.yml
@@ -42,12 +42,3 @@ runs:
       rm -rf sdk/emulator 2>/dev/null
       tar cf - sdk | zstd -T0 -3 > sdk.tar.zstd
     shell: bash
-  - name: Check/Install (Symlink)
-    run: |-
-      if [ -L /usr/local/bin/dx ] ; then
-        echo "Found symlink."
-        exit 0
-      fi
-      echo "Adding symlink..."
-      sudo ln -s $(pwd)/sdk/build-tools/29.0.2/dx /usr/local/bin/dx
-    shell: bash

--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,33 @@ AS_IF([test "x$enable_protobuf" = "xyes"], [
 ])
 AM_CONDITIONAL([SET_PROTOBUF],[test "x${enable_protobuf}" = "xyes"])
 
+# Check for Android SDK (for tests).
+AC_ARG_WITH([android-sdk],
+    [AS_HELP_STRING([--with-android-sdk=/path/to/android-sdk],
+        [Location of the Android SDK, for testing.])],
+    [ANDROID_HOME="$withval"],
+    [NO_ANDROID_HOME="no"]
+    [ AS_IF([test "x${PROTOC}" == "x"],
+        [AC_PATH_PROG([PROTOC], [protoc], [no])])
+    ]
+)
+# Look for dx & android.jar.
+AS_IF([test "x$NO_ANDROID_HOME" = "xno"],
+    [],
+    [
+        # Do not assume a totally new SDK. Try platform 29.
+        AC_PATH_PROG(
+            DX,
+            dx,
+            no,
+            "$ANDROID_HOME/build-tools/29.0.2:$PATH"
+        )
+        AS_IF([test "x$DX" = "xno"],
+            [AC_MSG_ERROR([--with-android-sdk option was specified but does not seem to point at a valid Android SDK installation])]
+            []
+        )
+    ]
+)
 
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h inttypes.h memory.h netinet/in.h stddef.h stdint.h stdlib.h string.h sys/time.h unistd.h])

--- a/test/Makefile.inc
+++ b/test/Makefile.inc
@@ -33,5 +33,4 @@ COMMON_MOCK_TEST_LIBS = \
 	$(top_builddir)/test/libgmock_main.la
 
 # By default use PATH to find tools.
-DX = dx
 JAVAC = javac

--- a/test/integ/Makefile.am
+++ b/test/integ/Makefile.am
@@ -1,6 +1,8 @@
 include $(top_srcdir)/Makefile.inc
 include $(top_srcdir)/test/Makefile.inc
 
+DX = @DX@
+
 AM_CXXFLAGS = --std=gnu++17
 AM_CPPFLAGS = $(COMMON_INCLUDES) $(COMMON_TEST_INCLUDES)
 


### PR DESCRIPTION
Summary:
Add `--with-android-sdk` to our automake setup.

This is now required for testing, as a version of dx in its build-tools will be used for dexing integ test jars.

Reviewed By: wsanville

Differential Revision: D59561184
