### PR TITLE
throw() -> noexcept

### DIFF
--- a/libredex/AggregateException.h
+++ b/libredex/AggregateException.h
@@ -19,7 +19,7 @@ class aggregate_exception : public std::exception {
       : m_exceptions(container.begin(), container.end()) {}
 
   // We do not really want to have this called directly
-  const char* what() const throw() override { return "one or more exception"; }
+  const char* what() const noexcept override { return "one or more exception"; }
 
   const std::vector<std::exception_ptr> m_exceptions;
 };

--- a/libredex/RedexException.cpp
+++ b/libredex/RedexException.cpp
@@ -29,7 +29,7 @@ RedexException::RedexException(
   m_msg = oss.str();
 }
 
-const char* RedexException::what() const throw() { return m_msg.c_str(); }
+const char* RedexException::what() const noexcept { return m_msg.c_str(); }
 
 void assert_or_throw(bool cond,
                      RedexError type,

--- a/libredex/RedexException.h
+++ b/libredex/RedexException.h
@@ -41,7 +41,7 @@ class RedexException : public std::exception {
       const std::string& message = "",
       const std::map<std::string, std::string>& extra_info = {});
 
-  const char* what() const throw() override;
+  const char* what() const noexcept override;
 
  private:
   std::string m_msg;


### PR DESCRIPTION
`throw()` is a deprecated syntax. `noexcept` is the appropriate replacement.