### PR TITLE
Change SDK cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,33 +159,37 @@ commands:
           command: |
             sudo apt-get install -y --no-install-recommends default-jdk-headless
 
-      - run:
-          name: Create cache key file for SDK Cache
-          command: |
-            echo "Cache key is: ${CACHE_VERSION}"
-            echo "${CACHE_VERSION}" > cache_version.rev
-
       - restore_cache:
           name: Restoring SDK Cache
           keys:
-            - android-build-tools-{{ checksum "cache_version.rev" }}
+            - v2-android-build-tools
 
       # We have to emulate cache behavior. Skip downloads if files exist.
       - run:
           name: Check/Install (SDK)
           command: |
-            if [ -e ~/sdk/build-tools/25.0.3/dx ] ; then
-              echo "Found SDK."
-              exit 0
+            if [ -e sdk/build-tools/29.0.2/dx ] ; then echo "Found SDK." ; exit 0 ; fi
+
+            # Check whether cache file exists, then check dx again.
+            if [ -f "sdk.tar.zstd" ] ; then
+              zstd --decompress --stdout sdk.tar.zstd | tar xf -
+              if [ -e sdk/build-tools/29.0.2/dx ] ; then echo "Unpacked SDK." ; exit 0 ; fi
             fi
+
+            # Download.
             echo "SDK missing, downloading..."
-            rm -rf ~/sdk 2>/dev/null
+            rm -rf sdk 2>/dev/null && mkdir -p sdk/cmdline-tools
+            echo "Downloading SDK to $(pwd)/sdk"
             wget https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip
-            mkdir -p ~/sdk/cmdline-tools
-            unzip commandlinetools-linux-6609375_latest.zip -d ~/sdk/cmdline-tools/
-            pushd ~/sdk/cmdline-tools/tools/bin >/dev/null
-            echo 'y' | ./sdkmanager --install 'build-tools;25.0.3'
+            unzip commandlinetools-linux-6609375_latest.zip -d sdk/cmdline-tools/
+            pushd sdk/cmdline-tools/tools/bin >/dev/null
+            echo 'y' | ./sdkmanager --install 'build-tools;29.0.2'
             popd >/dev/null
+
+            # Compress for cache. For reason see description of build cache.
+            # We do not need the emulator and it is large. Delete.
+            rm -rf sdk/emulator 2>/dev/null
+            tar cf - sdk | zstd -T0 -3 > sdk.tar.zstd
 
       - run:
           name: Check/Install (Symlink)
@@ -195,13 +199,13 @@ commands:
               exit 0
             fi
             echo "Adding symlink..."
-            sudo ln -s ~/sdk/build-tools/25.0.3/dx /usr/local/bin/dx
+            sudo ln -s $(pwd)/sdk/build-tools/29.0.2/dx /usr/local/bin/dx
 
       - save_cache:
           name: Saving SDK Cache
           paths:
-            - ~/sdk
-          key: android-build-tools-{{ checksum "cache_version.rev" }}
+            - sdk.tar.zstd
+          key: v2-android-build-tools
 
   # Level of indirection because there seems to be no way to set parameters
   # in the steps.

--- a/.github/actions/test-build-setup/action.yml
+++ b/.github/actions/test-build-setup/action.yml
@@ -14,23 +14,33 @@ runs:
   - name: Cache SDK
     uses: actions/cache@v3.3.2
     with:
-      key: android-build-tools-{{ steps.cache_version.outputs.CACHE_VERSION }}
-      path: ~/sdk
-      restore-keys: android-build-tools-{{ steps.cache_version.outputs.CACHE_VERSION }}
+      key: v1-android-build-tools
+      path: sdk.tar.zstd
+      restore-keys: v1-android-build-tools
   - name: Check/Install (SDK)
     run: |-
-      if [ -e ~/sdk/build-tools/25.0.3/dx ] ; then
-        echo "Found SDK."
-        exit 0
+      if [ -e sdk/build-tools/29.0.2/dx ] ; then echo "Found SDK." ; exit 0 ; fi
+
+      # Check whether cache file exists, then check dx again.
+      if [ -f "sdk.tar.zstd" ] ; then
+        zstd --decompress --stdout sdk.tar.zstd | tar xf -
+        if [ -e sdk/build-tools/29.0.2/dx ] ; then echo "Unpacked SDK." ; exit 0 ; fi
       fi
+
+      # Download.
       echo "SDK missing, downloading..."
-      rm -rf ~/sdk 2>/dev/null
+      rm -rf sdk 2>/dev/null && mkdir -p sdk/cmdline-tools
+      echo "Downloading SDK to $(pwd)/sdk"
       wget https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip
-      mkdir -p ~/sdk/cmdline-tools
-      unzip commandlinetools-linux-6609375_latest.zip -d ~/sdk/cmdline-tools/
-      pushd ~/sdk/cmdline-tools/tools/bin >/dev/null
-      echo 'y' | ./sdkmanager --install 'build-tools;25.0.3'
+      unzip commandlinetools-linux-6609375_latest.zip -d sdk/cmdline-tools/
+      pushd sdk/cmdline-tools/tools/bin >/dev/null
+      echo 'y' | ./sdkmanager --install 'build-tools;29.0.2'
       popd >/dev/null
+
+      # Compress for cache. For reason see description of build cache.
+      # We do not need the emulator and it is large. Delete.
+      rm -rf sdk/emulator 2>/dev/null
+      tar cf - sdk | zstd -T0 -3 > sdk.tar.zstd
     shell: bash
   - name: Check/Install (Symlink)
     run: |-
@@ -39,5 +49,5 @@ runs:
         exit 0
       fi
       echo "Adding symlink..."
-      sudo ln -s ~/sdk/build-tools/25.0.3/dx /usr/local/bin/dx
+      sudo ln -s $(pwd)/sdk/build-tools/29.0.2/dx /usr/local/bin/dx
     shell: bash


### PR DESCRIPTION
Summary:
Changes
* Use a simple key. No env variable. This requires changing code when updating, but that's OK.
* Compress the SDK for the cache. Similar to the build cache.
* Delete the emulator for caching. It is ~700MB.
* Upgrade to using API level 29.

Differential Revision: D59691477
