### PR TITLE
Supply android jar to unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ commands:
       - restore_cache:
           name: Restoring SDK Cache
           keys:
-            - v2-android-build-tools
+            - v3-android-build-tools
 
       # We have to emulate cache behavior. Skip downloads if files exist.
       - run:
@@ -184,6 +184,7 @@ commands:
             unzip commandlinetools-linux-6609375_latest.zip -d sdk/cmdline-tools/
             pushd sdk/cmdline-tools/tools/bin >/dev/null
             echo 'y' | ./sdkmanager --install 'build-tools;29.0.2'
+            ./sdkmanager --install 'platforms;android-29'
             popd >/dev/null
 
             # Compress for cache. For reason see description of build cache.
@@ -195,7 +196,7 @@ commands:
           name: Saving SDK Cache
           paths:
             - sdk.tar.zstd
-          key: v2-android-build-tools
+          key: v3-android-build-tools
 
   # Level of indirection because there seems to be no way to set parameters
   # in the steps.

--- a/.github/actions/test-build-setup/action.yml
+++ b/.github/actions/test-build-setup/action.yml
@@ -14,9 +14,9 @@ runs:
   - name: Cache SDK
     uses: actions/cache@v3.3.2
     with:
-      key: v1-android-build-tools
+      key: v3-android-build-tools
       path: sdk.tar.zstd
-      restore-keys: v1-android-build-tools
+      restore-keys: v3-android-build-tools
   - name: Check/Install (SDK)
     run: |-
       if [ -e sdk/build-tools/29.0.2/dx ] ; then echo "Found SDK." ; exit 0 ; fi
@@ -35,6 +35,7 @@ runs:
       unzip commandlinetools-linux-6609375_latest.zip -d sdk/cmdline-tools/
       pushd sdk/cmdline-tools/tools/bin >/dev/null
       echo 'y' | ./sdkmanager --install 'build-tools;29.0.2'
+      ./sdkmanager --install 'platforms;android-29'
       popd >/dev/null
 
       # Compress for cache. For reason see description of build cache.

--- a/configure.ac
+++ b/configure.ac
@@ -138,6 +138,15 @@ AS_IF([test "x$NO_ANDROID_HOME" = "xno"],
             [AC_MSG_ERROR([--with-android-sdk option was specified but does not seem to point at a valid Android SDK installation])]
             []
         )
+        AC_CHECK_FILE(
+            "$ANDROID_HOME/platforms/android-29/android.jar",
+            [
+                AC_SUBST(ANDROID_JAR,"$ANDROID_HOME/platforms/android-29/android.jar")
+                AC_SUBST(ANDROID_SDK,"$ANDROID_HOME")
+                AC_SUBST(ANDROID_PLATFORM_VERSION,29)
+            ],
+            [AC_MSG_ERROR([--with-android-sdk option was specified but does not seem to point at a valid Android SDK installation])]
+        )
     ]
 )
 

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -1,6 +1,9 @@
 include $(top_srcdir)/Makefile.inc
 include $(top_srcdir)/test/Makefile.inc
 
+ANDROID_SDK = @ANDROID_SDK@
+ANDROID_PLATFORM_VERSION = @ANDROID_PLATFORM_VERSION@
+
 AM_CXXFLAGS = --std=gnu++17
 AM_CPPFLAGS = $(COMMON_INCLUDES) $(COMMON_TEST_INCLUDES)
 
@@ -9,6 +12,11 @@ AM_CPPFLAGS += $(BOOST_CPPFLAGS)
 AM_LDFLAGS = $(BOOST_LDFLAGS)
 
 LDADD = $(COMMON_TEST_LIBS)
+
+# Need to set "sdk_path" environment variable to point to the SDK.
+# Need to set "android_target" for the platform version.
+LOG_COMPILER = sh
+AM_LOG_FLAGS = -c 'sdk_path=$(ANDROID_SDK) android_target=$(ANDROID_PLATFORM_VERSION) $0'
 
 # These need things in the environment.
 # XFAIL_TESTS = stringbuilder_outline_test throw_propagation_test


### PR DESCRIPTION
Summary: Use an `android.jar` from the required SDK to pass to unit tests. This should allow us to enable more tests in the future.

Reviewed By: wsanville

Differential Revision: D59661717
