### PR TITLE
Add a way to define test-specific env variables

### DIFF
--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -15,8 +15,27 @@ LDADD = $(COMMON_TEST_LIBS)
 
 # Need to set "sdk_path" environment variable to point to the SDK.
 # Need to set "android_target" for the platform version.
+# Set any env that a test wants if a test.env file is found.
 LOG_COMPILER = sh
-AM_LOG_FLAGS = -c 'sdk_path=$(ANDROID_SDK) android_target=$(ANDROID_PLATFORM_VERSION) $$0'
+AM_LOG_FLAGS = -c 'if [ -f $$0.env ] ; then source $$0.env ; fi ; sdk_path=$(ANDROID_SDK) android_target=$(ANDROID_PLATFORM_VERSION) $$0'
+
+# make_env: Simple helper to generate test-specific env.
+#
+# $1: test name
+# $2: space-separated list of env values
+#
+# Use: $(eval $(call make_env,test_name,a=b c=d))
+define make_env
+
+$(1).env:
+	rm -f $$@
+	$(foreach pair,$(2), echo "export $(pair)" >> $$@ ;)
+
+endef
+
+####
+# Actual test definitions
+####
 
 check_PROGRAMS = \
     aliased_registers_test \


### PR DESCRIPTION
Summary: If a test needs specific env variables set, it can provide a file named `{test}.env` that will be sourced before running the test. It is expected to contain exports to change the environment.

Reviewed By: wsanville

Differential Revision: D59949070
