### PR TITLE
Fix AM_LOG_FLAGS

### DIFF
--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -17,7 +17,7 @@ LDADD = $(COMMON_TEST_LIBS)
 # Need to set "android_target" for the platform version.
 # Set any env that a test wants if a test.env file is found.
 LOG_COMPILER = sh
-AM_LOG_FLAGS = -c 'if [ -f $$0.env ] ; then source $$0.env ; fi ; sdk_path=$(ANDROID_SDK) android_target=$(ANDROID_PLATFORM_VERSION) $$0'
+AM_LOG_FLAGS = -c 'if [ -f $$0.env ] ; then . ./$$0.env ; fi ; sdk_path=$(ANDROID_SDK) android_target=$(ANDROID_PLATFORM_VERSION) ./$$0'
 
 # make_env: Simple helper to generate test-specific env.
 #


### PR DESCRIPTION
Summary: `sh` is not always `bash` (or similar). Modern Debian, for example, uses `dash` - which does not support `source`. Fix the invocation to be POSIX-compliant.

Differential Revision: D60141728
