### PR TITLE
Refactor Github Actions workflows

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,14 +1,6 @@
-name: facebook/redex/build_main
+name: facebook/redex/build_and_test
 on:
-  pull_request:
-    branches:
-    - main
-    - stable
-  push:
-    branches:
-    - main
-  schedule:
-    - cron: 0 0 * * *
+  workflow_call
 env:
   CACHE_VERSION: xxxxx1
 jobs:
@@ -79,14 +71,3 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.1
     - uses: "./.github/actions/setup-build-and-test-windows"
-  build-windows-artifacts:
-    if: github.event_name == 'schedule'
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v4.1.1
-    - uses: "./.github/actions/setup-build-and-test-windows"
-    - uses: actions/upload-artifact@v4.0.0
-      with:
-        name: redex-windows
-        retention-days: 7
-        path: build/Redex*.zip

--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -1,0 +1,20 @@
+name: Build Main Nightly
+on:
+  schedule:
+    - cron: 0 0 * * *
+env:
+  CACHE_VERSION: xxxxx1
+jobs:
+  build:
+    uses: "./.github/workflows/build_and_test.yml"
+
+  build-windows-artifacts:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4.1.1
+    - uses: "./.github/actions/setup-build-and-test-windows"
+    - uses: actions/upload-artifact@v4.0.0
+      with:
+        name: redex-windows
+        retention-days: 7
+        path: build/Redex*.zip

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -1,0 +1,11 @@
+name: Build on Pull Request
+on:
+  pull_request:
+    branches:
+    - main
+    - stable
+env:
+  CACHE_VERSION: xxxxx1
+jobs:
+  build:
+    uses: "./.github/workflows/build_and_test.yml"

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -1,0 +1,11 @@
+name: Build on Push
+on:
+  push:
+    branches:
+    - main
+    - stable
+env:
+  CACHE_VERSION: xxxxx1
+jobs:
+  build:
+    uses: "./.github/workflows/build_and_test.yml"


### PR DESCRIPTION
Summary: Make the old `build_main.yml` a reusable workflow and separate out the different triggers into their own top-level workflow files. This somewhat simplifies the setup.

Differential Revision: D68498650
