### PR TITLE
Fix build errors with cmake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.0.2...4.0)
 project("Redex")
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake_modules" ${CMAKE_MODULE_PATH})

--- a/cmake_modules/Commons.cmake
+++ b/cmake_modules/Commons.cmake
@@ -53,7 +53,7 @@ macro(add_dependent_packages_for_redex)
     print_dirs("${ZLIB_INCLUDE_DIRS}" "ZLIB_INCLUDE_DIRS")
     print_dirs("${ZLIB_LIBRARIES}" "ZLIB_LIBRARIES")
 
-    find_package(Boost 1.71.0 REQUIRED COMPONENTS regex filesystem program_options iostreams thread)
+    find_package(Boost 1.71.0 REQUIRED COMPONENTS regex filesystem program_options iostreams thread CONFIG)
     print_dirs("${Boost_INCLUDE_DIRS}" "Boost_INCLUDE_DIRS")
     print_dirs("${Boost_LIBRARIES}" "Boost_LIBRARIES")
 


### PR DESCRIPTION
Summary:
CMake 4 now gives an error when the minimum version is below 3.5.
To work around this, we can use a range in `cmake_minimum_required`. The upper bound correspond to the maximum version of supported policies.

Another change is that `FindBoost.cmake` has been deleted, so we need to use `find_package(Boost [...] CONFIG)` now. Boost produces a config file since boost 1.70, and we require 1.71, so this should be fine.

Differential Revision: D72310898


