### PR TITLE
Fix open source build error

### DIFF
--- a/libredex/DeterministicContainers.h
+++ b/libredex/DeterministicContainers.h
@@ -83,6 +83,7 @@
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include "TemplateUtil.h"
 


### PR DESCRIPTION
Summary:
```
D:/a/redex/redex/libredex/DeterministicContainers.h:784:6: error: 'vector' in namespace 'std' does not name a template type
  784 | std::vector<std::pair<Key, Value>> unordered_order(Collection& collection,
      |      ^~~~~~
```

Differential Revision: D72311362


