### PR TITLE
Make `--disable-protobuf` not define `HAS_PROTOBUF`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,13 +34,13 @@ AC_CHECK_LIB([jsoncpp], [main], [], [AC_MSG_ERROR([Please install jsoncpp])])
 # check whether user enabled protobuf
 AC_ARG_ENABLE([protobuf],
     [AS_HELP_STRING([--enable-protobuf],
-        [Enable the protobuf for AppBundle build])],
-    [ AC_DEFINE(HAS_PROTOBUF) ]
+        [Enable the protobuf for AppBundle build])]
 )
 
 AS_IF([test "x$enable_protobuf" = "xyes"], [
     # user enabled protobuf
     # check if protobuf is installed
+    AC_DEFINE(HAS_PROTOBUF)
 
     # proto compiler
     # allow users to specify the path to protobuf compiler


### PR DESCRIPTION
Summary: Current script defines `HAS_PROTOBUF` if user provides any settings about `protobuf`, including `--disable-protobuf`, to the configuration script. Make sure this happens only if the user enables protobuf.

Differential Revision: D74630925


