### PR TITLE
Add an integration test for recursions with bitset in constant propagation

### DIFF
--- a/test/integ/Makefile.am
+++ b/test/integ/Makefile.am
@@ -61,6 +61,7 @@ if RUN_KOTLIN_TESTS
 check_PROGRAMS += \
     bitwise_ops_constant_propagation_test \
     kotlin_default_args_test \
+    recursive_bitset_constant_propagation_test \
     remove_redundant_nullcheck
 endif
 
@@ -110,6 +111,7 @@ if RUN_KOTLIN_TESTS
 TESTS += \
     bitwise_ops_constant_propagation_test \
     kotlin_default_args_test \
+    recursive_bitset_constant_propagation_test \
     remove_redundant_nullcheck
 endif
 
@@ -350,6 +352,8 @@ kotlin_default_args_test_SOURCES = KotlinDefaultArgsTest.cpp
 EXTRA_kotlin_default_args_test_DEPENDENCIES = kotlin_default_args_test-class.dex
 bitwise_ops_constant_propagation_test_SOURCES = BitwiseOpsConstantPropagationTest.cpp
 EXTRA_bitwise_ops_constant_propagation_test_DEPENDENCIES = bitwise_ops_constant_propagation_test-class.dex
+recursive_bitset_constant_propagation_test_SOURCES = RecursiveBitsetConstantPropagationTest.cpp
+EXTRA_recursive_bitset_constant_propagation_test_DEPENDENCIES = recursive_bitset_constant_propagation_test-class.dex
 remove_redundant_nullcheck_SOURCES = TypeAnalysisRemoveRedundantNullCheck.cpp
 EXTRA_remove_redundant_nullcheck_DEPENDENCIES = remove_redundant_nullcheck-class.dex
 
@@ -363,6 +367,9 @@ kotlin_default_args_test-class.jar: KotlinDefaultArgs.kt
 	$(create_jar_from_kotlin)
 
 bitwise_ops_constant_propagation_test-class.jar: BitwiseOpsConstantPropagationTest.kt
+	$(create_jar_from_kotlin)
+
+recursive_bitset_constant_propagation_test-class.jar: RecursiveBitsetConstantPropagation.kt
 	$(create_jar_from_kotlin)
 
 remove_redundant_nullcheck-class.jar: TypeAnalysisRemoveRedundantNullCheck.kt

--- a/test/integ/RecursiveBitsetConstantPropagation.kt
+++ b/test/integ/RecursiveBitsetConstantPropagation.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Test bitset interprocedural constant propagation with recursive use of bitset.
+// This extracts the core of bitset constant propagation in Composables without the rest of
+// Composable noises.
+class RecursiveBitsetConstantPropagation {
+  // flags plays a similar role to defaults in Composable, except not reused with a lambda.
+  private fun processWithNoLambda(count: Int, flags: Int) {
+    if (flags and 1 != 0) {
+      print("Lowest bit is set")
+    }
+    if (flags and 2 != 0) {
+      print("Second lowest bit is set")
+    }
+    if (count == 0) {
+      return
+    }
+    processWithNoLambda(count - 1, flags)
+  }
+
+  // flags plays a similar role to defaults in Composable. It is reused from within a lambda.
+  private fun processWithLambda(count: Int, flags: Int) {
+    if (flags and 1 != 0) {
+      print("Lowest bit is set")
+    }
+    if (flags and 2 != 0) {
+      print("Second lowest bit is set")
+    }
+    if (count == 0) {
+      return
+    }
+    // flags may be reused by an external caller calling callLambda.
+    takeALambda { processWithLambda(count - 1, flags) }
+  }
+
+  private fun takeALambda(f: () -> Unit) {
+    this.f = f
+  }
+
+  private var f = { -> Unit }
+
+  public fun callLambda() {
+    f()
+  }
+
+  public fun main() {
+    // Second lowest bit of flags is never set.
+    processWithNoLambda(1, 1)
+    processWithNoLambda(2, 1)
+    processWithLambda(1, 1)
+    processWithLambda(2, 1)
+  }
+}

--- a/test/integ/RecursiveBitsetConstantPropagationTest.cpp
+++ b/test/integ/RecursiveBitsetConstantPropagationTest.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <string>
+#include <string_view>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "DexUtil.h"
+#include "IPConstantPropagation.h"
+#include "RedexTest.h"
+#include "Resolver.h"
+#include "Show.h"
+
+namespace {
+
+using ::testing::HasSubstr;
+using ::testing::Not;
+using ::testing::NotNull;
+
+class RecursiveBitsetConstantPropagationTest
+    : public RedexIntegrationTest,
+      public ::testing::WithParamInterface<std::string> {
+ private:
+  void set_root_method(std::string_view full_name) {
+    auto method = DexMethod::get_method(full_name)->as_def();
+    ASSERT_THAT(method, NotNull()) << "method " << full_name << " not found";
+    method->rstate.set_root();
+  }
+
+ protected:
+  void SetUp() override {
+    static constexpr std::string_view main_method_sig =
+        "LRecursiveBitsetConstantPropagation;.main:()V";
+    RedexIntegrationTest::SetUp();
+    set_root_method(main_method_sig);
+    const auto main_method = DexMethod::get_method(main_method_sig)->as_def();
+    auto code_main = main_method->get_code();
+    ASSERT_THAT(code_main, NotNull()) << "main method not found";
+  }
+
+  const std::string& process_method_sig = GetParam();
+  static constexpr auto lowest_bit_set = "Lowest bit is set";
+  static constexpr auto second_lowest_bit_set = "Second lowest bit is set";
+};
+
+TEST_P(RecursiveBitsetConstantPropagationTest,
+       BeforeOptimizationAllBranchesArePresent) {
+  const auto process_method = DexMethod::get_method(process_method_sig);
+  ASSERT_TRUE(process_method->is_def()) << "process method not defined";
+  const auto code_process_method = process_method->as_def()->get_code();
+  ASSERT_THAT(code_process_method, NotNull()) << "process method not found";
+  EXPECT_THAT(assembler::to_string(code_process_method),
+              HasSubstr(lowest_bit_set))
+      << "The method does not have a block for lowest bit being set";
+  EXPECT_THAT(assembler::to_string(code_process_method),
+              HasSubstr(second_lowest_bit_set))
+      << "The method does not have a block for second lowest bit being set";
+}
+
+TEST_P(RecursiveBitsetConstantPropagationTest,
+       AfterOptimizationOnlySecondLowestBitIsGone) {
+  Pass* constp = new constant_propagation::interprocedural::PassImpl();
+  std::vector<Pass*> passes = {constp};
+  run_passes(passes);
+
+  const auto process_method = DexMethod::get_method(process_method_sig);
+  ASSERT_TRUE(process_method->is_def()) << "process method not defined";
+  const auto code_process_method = process_method->as_def()->get_code();
+  ASSERT_THAT(code_process_method, NotNull()) << "process method not found";
+  EXPECT_THAT(assembler::to_string(code_process_method),
+              HasSubstr(lowest_bit_set))
+      << "Lowest bit is set, but the method does not have a block for it";
+  EXPECT_THAT(assembler::to_string(code_process_method),
+              Not(HasSubstr(second_lowest_bit_set)))
+      << "Second lowest bit is not set, but the method has a block for it";
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    RecursiveBitsetConstantPropagationTests,
+    RecursiveBitsetConstantPropagationTest,
+    ::testing::Values(
+        "LRecursiveBitsetConstantPropagation;.processWithLambda:(II)V",
+        "LRecursiveBitsetConstantPropagation;.processWithNoLambda:(II)V"));
+
+} // namespace


### PR DESCRIPTION
Summary: This extracts the core of bitset constant propagation in Composables without the rest of Composable noises.

Differential Revision: D75815711


