### PR TITLE
Drop Ubuntu 20.04 support

### DIFF
--- a/cmake_modules/Commons.cmake
+++ b/cmake_modules/Commons.cmake
@@ -56,7 +56,7 @@ macro(add_dependent_packages_for_redex)
     print_dirs("${ZLIB_INCLUDE_DIRS}" "ZLIB_INCLUDE_DIRS")
     print_dirs("${ZLIB_LIBRARIES}" "ZLIB_LIBRARIES")
 
-    find_package(Boost 1.71.0 REQUIRED COMPONENTS regex filesystem program_options iostreams thread)
+    find_package(Boost 1.74.0 REQUIRED COMPONENTS regex filesystem program_options iostreams thread)
     print_dirs("${Boost_INCLUDE_DIRS}" "Boost_INCLUDE_DIRS")
     print_dirs("${Boost_LIBRARIES}" "Boost_LIBRARIES")
 

--- a/configure.ac
+++ b/configure.ac
@@ -17,12 +17,12 @@ LT_INIT
 
 AC_CONFIG_MACRO_DIR([m4])
 
-AM_PATH_PYTHON([3.0], [], [AC_MSG_ERROR([Redex requires python3])])
+AM_PATH_PYTHON([3.9], [], [AC_MSG_ERROR([Redex requires python >= 3.9])])
 
 # Checks for libraries.
 AX_PTHREAD
-AX_BOOST_BASE([1.71.0], [], [AC_MSG_ERROR(
-              [Please install boost >= 1.71 (including filesystem)])])
+AX_BOOST_BASE([1.74.0], [], [AC_MSG_ERROR(
+              [Please install boost >= 1.74 (including filesystem)])])
 AX_BOOST_FILESYSTEM
 AX_BOOST_REGEX
 AX_BOOST_PROGRAM_OPTIONS

--- a/setup_oss_toolchain.sh
+++ b/setup_oss_toolchain.sh
@@ -137,7 +137,7 @@ function handle_ubuntu {
             # We don't support JDK 21 yet. Replace this with default-jdk-headless once we support it.
             install_from_apt openjdk-17-jdk-headless kotlin ${DEB_UBUNTU_PKGS} ${BOOST_DEB_UBUNTU_PKGS} ${PROTOBUF_DEB_UBUNTU_PKGS}
             ;;
-        2*)
+        2[2-3]*)
             install_from_apt default-jdk-headless kotlin ${DEB_UBUNTU_PKGS} ${BOOST_DEB_UBUNTU_PKGS} ${PROTOBUF_DEB_UBUNTU_PKGS}
             ;;
         *)

--- a/setup_oss_toolchain.sh
+++ b/setup_oss_toolchain.sh
@@ -106,6 +106,7 @@ function install_from_apt {
         liblzma-dev$BITNESS_SUFFIX
         libtool
         make
+        python3
         wget
         zlib1g-dev$BITNESS_SUFFIX $BITNESS_PKGS $*"
   apt-get update -q
@@ -119,11 +120,11 @@ function handle_debian {
             exit 1
             ;;
         11)
-            install_from_apt python3 default-jdk-headless ${DEB_UBUNTU_PKGS} ${BOOST_DEB_UBUNTU_PKGS} ${PROTOBUF_DEB_UBUNTU_PKGS}
+            install_from_apt default-jdk-headless ${DEB_UBUNTU_PKGS} ${BOOST_DEB_UBUNTU_PKGS} ${PROTOBUF_DEB_UBUNTU_PKGS}
             install_kotlin_from_source
             ;;
         *)
-            install_from_apt python3 default-jdk-headless kotlin ${DEB_UBUNTU_PKGS} ${BOOST_DEB_UBUNTU_PKGS} ${PROTOBUF_DEB_UBUNTU_PKGS}
+            install_from_apt default-jdk-headless kotlin ${DEB_UBUNTU_PKGS} ${BOOST_DEB_UBUNTU_PKGS} ${PROTOBUF_DEB_UBUNTU_PKGS}
             ;;
     esac
     # TODO(T227009978): Install googletest from apt for some Debian versions after enabling autodetecting googletest installation dir.
@@ -134,10 +135,10 @@ function handle_ubuntu {
     case $1 in
         2[4-9]*)
             # We don't support JDK 21 yet. Replace this with default-jdk-headless once we support it.
-            install_from_apt python3 openjdk-17-jdk-headless kotlin ${DEB_UBUNTU_PKGS} ${BOOST_DEB_UBUNTU_PKGS} ${PROTOBUF_DEB_UBUNTU_PKGS}
+            install_from_apt openjdk-17-jdk-headless kotlin ${DEB_UBUNTU_PKGS} ${BOOST_DEB_UBUNTU_PKGS} ${PROTOBUF_DEB_UBUNTU_PKGS}
             ;;
         2*)
-            install_from_apt python3 default-jdk-headless kotlin ${DEB_UBUNTU_PKGS} ${BOOST_DEB_UBUNTU_PKGS} ${PROTOBUF_DEB_UBUNTU_PKGS}
+            install_from_apt default-jdk-headless kotlin ${DEB_UBUNTU_PKGS} ${BOOST_DEB_UBUNTU_PKGS} ${PROTOBUF_DEB_UBUNTU_PKGS}
             ;;
         *)
             echo "Unsupported Ubuntu version $1"

--- a/website/docs/getting_started/installation.md
+++ b/website/docs/getting_started/installation.md
@@ -23,10 +23,10 @@ brew install boost jsoncpp
 For App Bundle support `brew install protobuf` is also required.
 
 ### Ubuntu/Debian (64-bit)
-Base requirements are automake & libtool, GCC >= 9, Python >= 3.8 and Boost >= 1.71.0, as well as
-development versions of `iberty`, `jemalloc`, `jsoncpp`, `lz4`, `lzma`, and `zlib`. `Protobuf` >= 3.0 is required if optimizing an App Bundle.
-#### Ubuntu 20.04+, Debian 11(Bullseye)+
-The minimum supported Ubuntu version is 20.04. The minimum supported Debian version is 11.
+Base requirements are automake & libtool, GCC >= 10, Python >= 3.9 and Boost >= 1.74.0, as well as
+development versions of `iberty`, `jemalloc`, `jsoncpp`, `lz4`, `lzma`, and `zlib`. `Protobuf` >= 3.12.4 is required if optimizing an App Bundle.
+#### Ubuntu 22.04+, Debian 11(Bullseye)+
+The minimum supported Ubuntu version is 22.04. The minimum supported Debian version is 11.
 
 A [convenience script](https://github.com/facebook/redex/blob/master/setup_oss_toolchain.sh)
 will set up the build environment. This may include downloading googletest 1.14.0 on older OS versions.


### PR DESCRIPTION
Summary:
This enables us to require Python 3.9+, Boost 1.74+, protobuf 3.14.2+.

Rollback Plan:

Differential Revision: D77054424


