### PR TITLE
Remove `CONFIG` from boost lookup in CMake

### DIFF
--- a/cmake_modules/Commons.cmake
+++ b/cmake_modules/Commons.cmake
@@ -53,7 +53,7 @@ macro(add_dependent_packages_for_redex)
     print_dirs("${ZLIB_INCLUDE_DIRS}" "ZLIB_INCLUDE_DIRS")
     print_dirs("${ZLIB_LIBRARIES}" "ZLIB_LIBRARIES")
 
-    find_package(Boost 1.71.0 REQUIRED COMPONENTS regex filesystem program_options iostreams thread CONFIG)
+    find_package(Boost 1.71.0 REQUIRED COMPONENTS regex filesystem program_options iostreams thread)
     print_dirs("${Boost_INCLUDE_DIRS}" "Boost_INCLUDE_DIRS")
     print_dirs("${Boost_LIBRARIES}" "Boost_LIBRARIES")
 


### PR DESCRIPTION
Summary:
Internals:

D77045059 caused redex-oss-build-cmake to fail: https://www.internalfb.com/sandcastle/workflow/162129586593609441/actions

Based on D72446668, we shouldn't locate `CONFIG` . This restores the state of not looking up `CONFIG` before D77045059.

Differential Revision: D77056648


