### PR TITLE
Include boost, json, zlib as system headers in CMake

### DIFF
--- a/cmake_modules/Commons.cmake
+++ b/cmake_modules/Commons.cmake
@@ -27,6 +27,9 @@ macro(set_common_cxx_flags_for_redex)
             set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static -static-libgcc -static-libstdc++")
         endif ()
 
+        # TODO: WTemplate-body is a new feature in GCC 15: https://developers.redhat.com/articles/2025/04/24/new-c-features-gcc-15#new_and_improved_warnings
+        # It results in compilation error in at least one Boost header. Remove the following line when it's fixed.
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=template-body")
         set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -Wall -pthread")
         set(COMMON_CXX_FLAGS_NODBG "-O3 -UNDEBUG")
         set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${COMMON_CXX_FLAGS_NODBG} -pthread")

--- a/libredex/JsonWrapper.h
+++ b/libredex/JsonWrapper.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/libredex/Show.h
+++ b/libredex/Show.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <set>
 #include <sstream>

--- a/shared/file-utils.h
+++ b/shared/file-utils.h
@@ -9,6 +9,7 @@
 
 #include "Util.h"
 
+#include <cstdint>
 #include <cstdio>
 #include <memory>
 #include <string>


### PR DESCRIPTION
Summary:
We are uninterested in warnings caused by these header files, which can cause errors due to `-Wall` and `-Wextra`.

Rollback Plan:

Differential Revision: D77201401


