### PR TITLE
Install googletest from apt when the distribution includes a version >= 1.14.0

### DIFF
--- a/setup_oss_toolchain.sh
+++ b/setup_oss_toolchain.sh
@@ -52,6 +52,9 @@ BOOST_DEB_UBUNTU_PKGS="libboost-filesystem-dev$BITNESS_SUFFIX
 PROTOBUF_DEB_UBUNTU_PKGS="libprotobuf-dev$BITNESS_SUFFIX
                           protobuf-compiler"
 
+GOOGLETEST_DEB_UBUNTU_PKGS="libgtest-dev$BITNESS_SUFFIX
+                            libgmock-dev$BITNESS_SUFFIX"
+
 function install_googletest_from_source {
     pushd "$TOOLCHAIN_TMP"
     mkdir -p dl_cache/gtest
@@ -115,38 +118,40 @@ function install_from_apt {
 
 function handle_debian {
     case $1 in
-        [1-9]|10)
-            echo "Unsupported Debian version $1"
-            exit 1
+        1[3-9])
+            install_from_apt default-jdk-headless kotlin ${DEB_UBUNTU_PKGS} ${BOOST_DEB_UBUNTU_PKGS} ${PROTOBUF_DEB_UBUNTU_PKGS} ${GOOGLETEST_DEB_UBUNTU_PKGS}
+            ;;
+        12)
+            install_from_apt default-jdk-headless kotlin ${DEB_UBUNTU_PKGS} ${BOOST_DEB_UBUNTU_PKGS} ${PROTOBUF_DEB_UBUNTU_PKGS}
+            install_googletest_from_source
             ;;
         11)
             install_from_apt default-jdk-headless ${DEB_UBUNTU_PKGS} ${BOOST_DEB_UBUNTU_PKGS} ${PROTOBUF_DEB_UBUNTU_PKGS}
             install_kotlin_from_source
+            install_googletest_from_source
             ;;
         *)
-            install_from_apt default-jdk-headless kotlin ${DEB_UBUNTU_PKGS} ${BOOST_DEB_UBUNTU_PKGS} ${PROTOBUF_DEB_UBUNTU_PKGS}
+            echo "Unsupported Debian version $1"
+            exit 1
             ;;
     esac
-    # TODO(T227009978): Install googletest from apt for some Debian versions after enabling autodetecting googletest installation dir.
-    install_googletest_from_source
 }
 
 function handle_ubuntu {
     case $1 in
         2[4-9]*)
             # We don't support JDK 21 yet. Replace this with default-jdk-headless once we support it.
-            install_from_apt openjdk-17-jdk-headless kotlin ${DEB_UBUNTU_PKGS} ${BOOST_DEB_UBUNTU_PKGS} ${PROTOBUF_DEB_UBUNTU_PKGS}
+            install_from_apt openjdk-17-jdk-headless kotlin ${DEB_UBUNTU_PKGS} ${BOOST_DEB_UBUNTU_PKGS} ${PROTOBUF_DEB_UBUNTU_PKGS} ${GOOGLETEST_DEB_UBUNTU_PKGS}
             ;;
         2[2-3]*)
             install_from_apt default-jdk-headless kotlin ${DEB_UBUNTU_PKGS} ${BOOST_DEB_UBUNTU_PKGS} ${PROTOBUF_DEB_UBUNTU_PKGS}
+            install_googletest_from_source
             ;;
         *)
             echo "Unsupported Ubuntu version $1"
             exit 1
             ;;
     esac
-    # TODO(T227009978): Install googletest from apt for some Ubuntu versions after enabling autodetecting googletest installation dir.
-    install_googletest_from_source
 }
 
 # Read ID and VERSION_ID from /etc/os-release.


### PR DESCRIPTION
Summary:
Later distributions have googletest >= 1.14.0 ready

Rollback Plan:

Differential Revision: D77470725


