### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,7 +31,7 @@ jobs:
       run: cat /etc/os-release
     - name: Install prerequisites for checking out the repo
       run: apt-get update && apt-get install -y --no-install-recommends ca-certificates git-core
-    - uses: actions/checkout@v4.1.1
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/prepare_debian"
     - uses: ./.github/actions/setup-build-and-test-w-make
       with:
@@ -57,7 +57,7 @@ jobs:
         - 19
         - 18
     steps:
-    - uses: actions/checkout@v4.1.1
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/prepare_debian"
       with:
         install_clang_llvm_org: "${{ matrix.clang_version }}"
@@ -70,5 +70,5 @@ jobs:
   build-windows:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v4.1.1
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/setup-build-and-test-windows"

--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -11,9 +11,9 @@ jobs:
   build-windows-artifacts:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v4.1.1
+    - uses: actions/checkout@v6
     - uses: "./.github/actions/setup-build-and-test-windows"
-    - uses: actions/upload-artifact@v4.0.0
+    - uses: actions/upload-artifact@v6
       with:
         name: redex-windows
         retention-days: 7

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -16,8 +16,8 @@ jobs:
       run:
         working-directory: website
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: yarn


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [``](https://github.com/actions/checkout/releases/tag/) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) |  |
| `actions/setup-node` | [``](https://github.com/actions/setup-node/releases/tag/) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Release](https://github.com/actions/setup-node/releases/tag/v6) |  |
| `actions/upload-artifact` | [``](https://github.com/actions/upload-artifact/releases/tag/) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) |  |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
