### PR TITLE
Update Clang versions in GitHub workflow to 19/20/latest

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -53,9 +53,9 @@ jobs:
         # We intentionally don't explicitly spell out all versions, so that 0
         # will always track the default from apt.llvm.org (usually the latest
         # stable clang).
-        - 0  # At time of edit 20.
+        - 0  # At time of edit 21.
+        - 20
         - 19
-        - 18
     steps:
     - uses: actions/checkout@v6
     - uses: "./.github/actions/prepare_debian"


### PR DESCRIPTION
Summary:
apt.llvm.org now provides Clang 21 as the latest stable version. Bump the
explicitly specified Clang versions from 18/19 to 19/20 to continue testing
the three most recent stable Clang releases.

Differential Revision: D91352949


