### PR TITLE
Remove Debian 11 support

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,10 +11,6 @@ jobs:
     strategy:
       matrix:
         config:
-        # Extra flags for problematic early verisons of # jsoncpp < 1.9.5
-        # (https://github.com/open-source-parsers/jsoncpp/issues/1193).  This
-        # currently only affects Debian 11.
-        - {os: "debian:11", configure_extra: "CXXFLAGS=-Wno-volatile"}
         # Extra flags for false positives from GCC 12:
         # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105651
         - {os: "debian:12", configure_extra: "CXXFLAGS=-Wno-restrict"}

--- a/setup_oss_toolchain.sh
+++ b/setup_oss_toolchain.sh
@@ -79,22 +79,6 @@ function install_googletest_from_source {
     popd
 }
 
-function install_kotlin_from_source {
-    pushd "$TOOLCHAIN_TMP"
-    mkdir -p dl_cache/kotlin
-    KOTLIN_VERSION=1.3.31
-    if [ ! -f "dl_cache/kotlin/kotlin-compiler-${KOTLIN_VERSION}.zip" ] ; then
-        wget "https://github.com/JetBrains/kotlin/releases/download/v${KOTLIN_VERSION}/kotlin-compiler-${KOTLIN_VERSION}.zip" -O "dl_cache/kotlin/kotlin-compiler-${KOTLIN_VERSION}.zip"
-    fi
-    mkdir -p toolchain_install/kotlin
-    pushd toolchain_install/kotlin
-    unzip "../../dl_cache/kotlin/kotlin-compiler-${KOTLIN_VERSION}.zip"
-    cp -v kotlinc/bin/* /usr/local/bin
-    cp -v kotlinc/lib/* /usr/local/lib
-    popd
-    popd
-}
-
 function install_from_apt {
   PKGS="autoconf
         autoconf-archive
@@ -125,11 +109,6 @@ function handle_debian {
             ;;
         12)
             install_from_apt kotlin ${DEB_UBUNTU_PKGS} ${BOOST_DEB_UBUNTU_PKGS} ${PROTOBUF_DEB_UBUNTU_PKGS}
-            install_googletest_from_source
-            ;;
-        11)
-            install_from_apt ${DEB_UBUNTU_PKGS} ${BOOST_DEB_UBUNTU_PKGS} ${PROTOBUF_DEB_UBUNTU_PKGS}
-            install_kotlin_from_source
             install_googletest_from_source
             ;;
         *)


### PR DESCRIPTION
Summary:
Debian 11 (Bullseye) reached end-of-life and is currently only supported as LTS. This diff removes Debian 11
from the CI build matrix and cleans up the now-unused
`install_kotlin_from_source` function that was only needed for Debian 11.

Differential Revision: D92358421


