### PR TITLE
Fix `git-restore-mtime` for newer Git on GitHub Actions (#983)

### DIFF
--- a/.github/actions/debian-based-image-build-setup/action.yml
+++ b/.github/actions/debian-based-image-build-setup/action.yml
@@ -16,7 +16,15 @@ runs:
     run: sudo apt-get -qq update || ( apt-get -qq update && apt-get -qq install --no-install-recommends -y sudo ; )
     shell: bash
   - name: Install tools
-    run: sudo apt-get install -qq --no-install-recommends -y git-restore-mtime zstd tar
+    run: sudo apt-get install -qq --no-install-recommends -y zstd tar curl python3
+    shell: bash
+  - name: Install git-restore-mtime
+    # The GitHub Actions runner ships a Git version newer than the distro's,
+    # which can break the distro's git-restore-mtime package. Install a
+    # newer version directly from upstream.
+    run: |
+      sudo curl -fsSL -o /usr/local/bin/git-restore-mtime https://raw.githubusercontent.com/MestreLion/git-tools/v2025.08/git-restore-mtime
+      sudo chmod +x /usr/local/bin/git-restore-mtime
     shell: bash
   - name: Add 32-bit Arch
     run: sudo dpkg --add-architecture i386 && sudo apt-get update

--- a/.github/actions/setup-build-and-test-w-make-impl/action.yml
+++ b/.github/actions/setup-build-and-test-w-make-impl/action.yml
@@ -29,11 +29,11 @@ runs:
   - name: Cache build
     uses: actions/cache@v4
     with:
-      key: v2-build-cache-${{ inputs.job_name }}.${{ inputs.setup_toolchain_extra }}.${{ inputs.configure_extra }}-${{ runner.arch }}-${{ github.ref_name }}-${{ github.sha }}
+      key: v3-build-cache-${{ inputs.job_name }}.${{ inputs.setup_toolchain_extra }}.${{ inputs.configure_extra }}-${{ runner.arch }}-${{ github.ref_name }}-${{ github.sha }}
       path: build.tar.zstd
       restore-keys: |
-        v2-build-cache-${{ inputs.job_name }}.${{ inputs.setup_toolchain_extra }}.${{ inputs.configure_extra }}-${{ runner.arch }}-${{ github.ref_name }}-
-        v2-build-cache-${{ inputs.job_name }}.${{ inputs.setup_toolchain_extra }}.${{ inputs.configure_extra }}-${{ runner.arch }}-${{ github.base_ref }}-
+        v3-build-cache-${{ inputs.job_name }}.${{ inputs.setup_toolchain_extra }}.${{ inputs.configure_extra }}-${{ runner.arch }}-${{ github.ref_name }}-
+        v3-build-cache-${{ inputs.job_name }}.${{ inputs.setup_toolchain_extra }}.${{ inputs.configure_extra }}-${{ runner.arch }}-${{ github.base_ref }}-
   # Would be nice to use the cache action output, but we want to unpack even on
   # restore_keys hit.
   - name: Unpack build cache


### PR DESCRIPTION
Summary:

The GitHub Actions runner ships Git 2.53, which is newer than Ubuntu 24.04's default Git 2.43. Git 2.53 removed `git whatchanged`, which the distro's `git-restore-mtime` package (version 2022.12) relies on. This causes `git-restore-mtime` to fail silently, leaving all source files with the checkout timestamp. With stale build cache objects, Make's dependency tracking can miss recompilation of files affected by header changes, leading to test failures from mismatched struct layouts.

Install `git-restore-mtime` v2025.08 directly from upstream, which uses `git log --raw` instead of `git whatchanged`.

Differential Revision: D100770813


