### PR TITLE
Add failure preservation and artifact upload for GTest XML results (#985)

### DIFF
--- a/.github/actions/setup-build-and-test-w-make-impl/action.yml
+++ b/.github/actions/setup-build-and-test-w-make-impl/action.yml
@@ -70,10 +70,37 @@ runs:
     working-directory: build
     shell: bash
   - name: Run tests
+    id: run-tests
     run: |-
       mkdir -p /tmp/test-results
+      rm -f /tmp/test-results/*.xml
       export GTEST_OUTPUT=xml:/tmp/test-results/
+      set +e
       make -j4 check V=0
+      rc=$?
+      echo "exit_code=$rc" >> "$GITHUB_OUTPUT"
+      exit 0
     working-directory: build
     if: inputs.run_tests == 'true'
+    shell: bash
+  - name: Sanitize artifact name
+    id: artifact-name
+    if: inputs.run_tests == 'true' && (success() || failure())
+    run: |-
+      name="test-results-${{ inputs.job_name }}"
+      name="${name//[:\"<>|*?\\\/]/-}"
+      name="${name// /_}"
+      echo "name=$name" >> "$GITHUB_OUTPUT"
+    shell: bash
+  - name: Upload test results
+    if: inputs.run_tests == 'true' && (success() || failure())
+    uses: actions/upload-artifact@v4
+    with:
+      name: ${{ steps.artifact-name.outputs.name }}
+      path: /tmp/test-results/
+      if-no-files-found: ignore
+      retention-days: 14
+  - name: Fail job on test failure
+    if: steps.run-tests.outputs.exit_code != '0' && steps.run-tests.outputs.exit_code != ''
+    run: exit 1
     shell: bash


### PR DESCRIPTION
Summary:

The Redex CI composite action already sets GTEST_OUTPUT=xml:/tmp/test-results/ to generate GTest XML reports, but the XML files were never uploaded and were lost when the runner exited. Additionally, if tests failed, subsequent steps would not run.

This change adds three things to setup-build-and-test-w-make-impl/action.yml:

1. **Exit code capture**: The "Run tests" step now uses `set +e` and captures the exit code to `$GITHUB_OUTPUT` instead of failing immediately. This ensures subsequent steps (artifact upload) always run. Also clears stale XML files before running tests.

2. **Artifact upload**: A new `actions/upload-artifact@v4` step uploads /tmp/test-results/ with unique artifact names per matrix entry (using `inputs.job_name`). Uses `if-no-files-found: ignore` so 32-bit builds that skip tests are unaffected. 14-day retention.

3. **Failure gate**: A final step checks the captured exit code and runs `exit 1` if tests failed, preserving the red failure signal on the job after artifacts are safely uploaded.

Differential Revision: D102739348


