### PR TITLE
Bump GitHub Actions runner to 8-core-ubuntu (#987)

### DIFF
--- a/.github/actions/setup-build-and-test-w-make-impl/action.yml
+++ b/.github/actions/setup-build-and-test-w-make-impl/action.yml
@@ -59,14 +59,18 @@ runs:
     working-directory: build
     shell: bash
   - name: Build
-    run: make -j4 V=0
+    run: |
+      set -x
+      make -j"$(nproc)" V=0
     working-directory: build
     shell: bash
   - name: Compress build directory
     run: tar cf - build | zstd -T0 -3 > build.tar.zstd
     shell: bash
   - name: Build tests
-    run: make -j4 check TESTS= V=0
+    run: |
+      set -x
+      make -j"$(nproc)" check TESTS= V=0
     working-directory: build
     shell: bash
   - name: Run tests
@@ -76,7 +80,8 @@ runs:
       rm -f /tmp/test-results/*.xml
       export GTEST_OUTPUT=xml:/tmp/test-results/
       set +e
-      make -j4 check V=0
+      set -x
+      make -j"$(nproc)" check V=0
       rc=$?
       echo "exit_code=$rc" >> "$GITHUB_OUTPUT"
       exit 0

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -6,7 +6,7 @@ env:
 jobs:
   linux-gcc:
     name: Linux GCC - ${{ matrix.config.os }} - ${{ matrix.build_arch }}
-    runs-on: 4-core-ubuntu
+    runs-on: 8-core-ubuntu
     container: ${{ matrix.config.os }}
     strategy:
       matrix:
@@ -37,7 +37,7 @@ jobs:
         job_name: Linux GCC - ${{ matrix.config.os }} - ${{ matrix.build_arch }}
 
   build-deb_stable-w-clang-llvm-org:
-    runs-on: 4-core-ubuntu
+    runs-on: 8-core-ubuntu
     env:
       CC: clang
       CXX: clang++


### PR DESCRIPTION
Summary:

Switch the Linux build/test jobs from `4-core-ubuntu` to `8-core-ubuntu` to speed up CI.

Differential Revision: D102890552


