### PR TITLE
Pass `VERBOSE=1` to `make check` so failed test logs are dumped

### DIFF
--- a/.github/actions/setup-build-and-test-w-make-impl/action.yml
+++ b/.github/actions/setup-build-and-test-w-make-impl/action.yml
@@ -76,7 +76,7 @@ runs:
       rm -f /tmp/test-results/*.xml
       export GTEST_OUTPUT=xml:/tmp/test-results/
       set +e
-      make -j4 check V=0
+      make -j4 check V=1 VERBOSE=1
       rc=$?
       echo "exit_code=$rc" >> "$GITHUB_OUTPUT"
       exit 0


### PR DESCRIPTION
Summary:
Automake's parallel test harness only prints `PASS:`/`FAIL:` summaries by default. When a test fails on the GitHub CI runner, the actual error message lives in `test/unit/test-suite.log` (and the per-test `.log` files), which we never get to see because the harness just points at them and exits.

Setting `VERBOSE=1` tells the harness to dump those logs to stdout after the summary, so a failure like the recent `clinit_batching_pass_test` regression shows the real output directly in the GitHub Actions log. `V=1` is also passed so any incidental rebuild output is shown in full rather than via silent rules.

Differential Revision: D102907004


