### PR TITLE
Add Ubuntu 26.04 to GitHub Actions test matrix

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,6 +17,7 @@ jobs:
         - {os: "debian:13", configure_extra: ""}
         - {os: "ubuntu:22.04", configure_extra: ""}
         - {os: "ubuntu:24.04", configure_extra: ""}
+        - {os: "ubuntu:26.04", configure_extra: ""}
         - {os: "gcc:latest", configure_extra: ""}
         build_arch: ["x86_64"]
         include:


### PR DESCRIPTION
Summary: Add `ubuntu:26.04` to the OSS CI.

Differential Revision: D103910358


