### PR TITLE
ci: declare workflow-level `contents: read` on 3 workflows

### DIFF
--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -4,6 +4,10 @@ on:
     - cron: 0 0 * * *
 env:
   CACHE_VERSION: xxxxx1
+
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: "./.github/workflows/build_and_test.yml"

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -6,6 +6,10 @@ on:
     - stable
 env:
   CACHE_VERSION: xxxxx1
+
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: "./.github/workflows/build_and_test.yml"

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -6,6 +6,10 @@ on:
     - stable
 env:
   CACHE_VERSION: xxxxx1
+
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: "./.github/workflows/build_and_test.yml"


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 3 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `build_and_test.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.