### PR TITLE
Fix compilation errors, support building Redex in Termux

### DIFF
--- a/libresource/ResourceTypes.cpp
+++ b/libresource/ResourceTypes.cpp
@@ -41,6 +41,9 @@
 #include "utils/String16.h"
 #include "utils/String8.h"
 
+#ifdef __TERMUX__
+#undef __ANDROID__
+#endif
 #ifdef __ANDROID__
 #include <binder/TextOutput.h>
 #endif

--- a/libresource/utils/TypeHelpers.h
+++ b/libresource/utils/TypeHelpers.h
@@ -195,7 +195,7 @@ template<typename TYPE>
 typename std::enable_if<use_trivial_move<TYPE>::value>::type
 inline
 move_forward_type(TYPE* d, const TYPE* s, size_t n = 1) {
-    memmove(d, s, n*sizeof(TYPE));
+    memmove((void *)d, (void *)s, n*sizeof(TYPE));
 }
 
 template<typename TYPE>
@@ -222,7 +222,7 @@ template<typename TYPE>
 typename std::enable_if<use_trivial_move<TYPE>::value>::type
 inline
 move_backward_type(TYPE* d, const TYPE* s, size_t n = 1) {
-    memmove(d, s, n*sizeof(TYPE));
+    memmove((void *)d, (void *)s, n*sizeof(TYPE));
 }
 
 template<typename TYPE>

--- a/selfextract.sh
+++ b/selfextract.sh
@@ -4,7 +4,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-export TMPDIR=`mktemp -d /tmp/redex.XXXXXX`
+TERMUX_TMP=""
+if pwd | grep -q "termux"; then
+TERMUX_TMP="/data/data/com.termux/cache"
+mkdir -p $TERMUX_TMP/tmp
+fi
+
+export TMPDIR=`mktemp -d "$TERMUX_TMP/tmp/redex.XXXXXX"`
 ARCHIVE=`awk '/^__ARCHIVE_BELOW__/ { print NR + 1; exit 0 }' $0`
 tail -n+$ARCHIVE $0 | tar xz -C $TMPDIR
 

--- a/tools/redexdump/RedexDump.cpp
+++ b/tools/redexdump/RedexDump.cpp
@@ -68,7 +68,7 @@ int main(int argc, char* argv[]) {
   uint32_t ddebug_offset = 0;
   int no_headers = 0;
 
-  char c;
+  int c;
   static const struct option options[] = {
       {"all", no_argument, nullptr, 'a'},
       {"string", no_argument, nullptr, 's'},


### PR DESCRIPTION
You can use the following method to build

First, install the dependencies:

pkg install build-essential
pkg install libandroid-execinfo

Set up environment variables. You need to set the correct Boost library path. the Boost here was installed by compiling from source:

BOOST_ROOT=$HOME/boost
INSTALL_DIR=$HOME/redex_install
SRC_DIR=$HOME/redex

Compile:

cd $SRC_DIR

autoreconf -ivf

CPPFLAGS="-D__TERMUX__" ./configure \
--prefix=$INSTALL_DIR \
--disable-tests --disable-kotlin-tests \
--with-boost-libdir=$BOOST_ROOT/lib

make -j8 && make install

Set up the environment and run:

export PATH=$INSTALL_DIR/bin:$PATH

cd ~
python3 -m venv env_redex
. env_redex/bin/activate

pip3 install packaging

redex --help