### PR TITLE
Fix IRList::structural_equals to ignore MFLOW_FALLTHROUGH

### DIFF
--- a/libredex/IRList.cpp
+++ b/libredex/IRList.cpp
@@ -791,19 +791,23 @@ bool IRList::structural_equals(
     auto p = delayed_matches.emplace(mie1, mie2);
     return p.second || p.first->second == mie2;
   };
-  for (; it1 != m_list.end() && it2 != other.end();) {
+  // Skip metadata (debug, position, source block, remark) and no-op
+  // (MFLOW_FALLTHROUGH) entries. These carry neither code nor control flow, so
+  // they are elided when comparing two IRLists for structural equality.
+  auto skip_noops = [&](IRList::iterator& it, const IRList& list) {
+    while (it != list.end() &&
+           (is_metadata(it->type) || it->type == MFLOW_FALLTHROUGH)) {
+      ++it;
+    }
+  };
+  for (;;) {
+    skip_noops(it1, *this);
+    skip_noops(it2, other);
+    if (it1 == this->end() || it2 == other.end()) {
+      break;
+    }
     always_assert(it1->type != MFLOW_DEX_OPCODE);
     always_assert(it2->type != MFLOW_DEX_OPCODE);
-    // Skip metadata (debug, position, source block, remark).
-    if (is_metadata(it1->type)) {
-      ++it1;
-      continue;
-    }
-
-    if (is_metadata(it2->type)) {
-      ++it2;
-      continue;
-    }
 
     if (it1->type != it2->type) {
       return false;

--- a/libredex/IRList.cpp
+++ b/libredex/IRList.cpp
@@ -794,7 +794,7 @@ bool IRList::structural_equals(
   // Skip metadata (debug, position, source block, remark) and no-op
   // (MFLOW_FALLTHROUGH) entries. These carry neither code nor control flow, so
   // they are elided when comparing two IRLists for structural equality.
-  auto skip_noops = [&](IRList::iterator& it, const IRList& list) {
+  auto skip_noops = [&](IRList::const_iterator& it, const IRList& list) {
     while (it != list.end() &&
            (is_metadata(it->type) || it->type == MFLOW_FALLTHROUGH)) {
       ++it;

--- a/test/unit/IRListTest.cpp
+++ b/test/unit/IRListTest.cpp
@@ -249,3 +249,64 @@ TEST_F(IRListTest, keep_valid_regs) {
   EXPECT_EQ(assembler::to_string(expected_code.get()),
             assembler::to_string(code.get()));
 }
+
+TEST_F(IRListTest, structural_equals_ignores_fallthrough) {
+  // An unused label is lowered to a MFLOW_FALLTHROUGH entry. It carries no
+  // code or control flow, so it must not break structural equality.
+  auto code = assembler::ircode_from_string(R"(
+    (
+      (load-param v0)
+      (return-void)
+    )
+  )");
+  auto code_with_fallthrough = assembler::ircode_from_string(R"(
+    (
+      (load-param v0)
+      (:unused_label)
+      (return-void)
+    )
+  )");
+
+  EXPECT_TRUE(code->structural_equals(*code_with_fallthrough));
+  EXPECT_TRUE(code_with_fallthrough->structural_equals(*code));
+}
+
+TEST_F(IRListTest, structural_equals_ignores_trailing_noops) {
+  // No-op and metadata entries at the end of one method while the other has
+  // already been fully consumed must not break structural equality.
+  auto code = assembler::ircode_from_string(R"(
+    (
+      (load-param v0)
+      (return-void)
+    )
+  )");
+  auto code_with_trailing_noop = assembler::ircode_from_string(R"(
+    (
+      (load-param v0)
+      (return-void)
+      (:unused_label)
+    )
+  )");
+
+  EXPECT_TRUE(code->structural_equals(*code_with_trailing_noop));
+  EXPECT_TRUE(code_with_trailing_noop->structural_equals(*code));
+}
+
+TEST_F(IRListTest, structural_equals_still_detects_differences) {
+  auto code1 = assembler::ircode_from_string(R"(
+    (
+      (load-param v0)
+      (const v0 0)
+      (return-void)
+    )
+  )");
+  auto code2 = assembler::ircode_from_string(R"(
+    (
+      (load-param v0)
+      (const v0 1)
+      (return-void)
+    )
+  )");
+
+  EXPECT_FALSE(code1->structural_equals(*code2));
+}


### PR DESCRIPTION
Fixes #778

`IRList::structural_equals` compared every entry in the IR lists, including `MFLOW_FALLTHROUGH` no-ops, so two methods that differ only in the placement of a no-op (e.g. an unreferenced label lowered to FALLTHROUGH) were reported as not structurally equal. Trailing metadata/no-op entries after the last real instruction also caused a mismatch when the other list had already been fully consumed.

This change skips metadata and FALLTHROUGH entries on both sides before each comparison step, and skips any remaining trailing no-ops after the main loop. Unit tests are added for leading and trailing FALLTHROUGH entries, plus a negative case ensuring real differences are still detected.